### PR TITLE
Updating nhc forecast lines to use best track as long as possible

### DIFF
--- a/containers/build/message_handler.py
+++ b/containers/build/message_handler.py
@@ -439,9 +439,12 @@ class MessageHandler:
         start_date = btk_lines[0]["date"]
         start_date_str = datetime.strftime(start_date, "%Y%m%d%H")
 
+        time_list = []
+
         with open(output_file, "w") as merge:
             for line in btk_lines:
-                if line["date"] < fcst_lines[0]["date"]:
+                if line["date"] <= fcst_lines[0]["date"]:
+                    time_list.append(line["date"])
                     dt = int((line["date"] - start_date).total_seconds() / 3600.0)
                     dt_str = "{:4d}".format(dt)
                     sub1 = line["line"][:8]
@@ -451,13 +454,14 @@ class MessageHandler:
                     merge.write(line_new + "\n")
 
             for line in fcst_lines:
-                dt = int((line["date"] - start_date).total_seconds() / 3600.0)
-                dt_str = "{:4d}".format(dt)
-                sub1 = line["line"][:8]
-                sub2 = line["line"][18:29]
-                sub3 = line["line"][33:]
-                line_new = sub1 + start_date_str + sub2 + dt_str + sub3
-                merge.write(line_new + "\n")
+                if line["date"] not in time_list:
+                    dt = int((line["date"] - start_date).total_seconds() / 3600.0)
+                    dt_str = "{:4d}".format(dt)
+                    sub1 = line["line"][:8]
+                    sub2 = line["line"][18:29]
+                    sub3 = line["line"][33:]
+                    line_new = sub1 + start_date_str + sub2 + dt_str + sub3
+                    merge.write(line_new + "\n")
 
         return output_file
 


### PR DESCRIPTION
This will help ensure that metget does not use the forecast zero hour if it is available in the best track data (thanks @tgasher). It is possible that there could be a pressure difference because the forecast does not have a pressure available, which leads to the system using a knaff-zher computed pressure, leading to a potential discontinuity at simulation startup