### PR TITLE
Checking for the grib2 index file on NOAA before considering the file available

### DIFF
--- a/src/executables/api/src/metget_api/api.py
+++ b/src/executables/api/src/metget_api/api.py
@@ -89,7 +89,7 @@ class MetGetStatus(Resource):
     """
 
     decorators: ClassVar = [
-        limiter.limit("10/second", on_breach=ratelimit_error_responder)
+        limiter.limit("30/second", on_breach=ratelimit_error_responder)
     ]
 
     @staticmethod
@@ -117,7 +117,7 @@ class MetGetBuild(Resource):
     """
 
     decorators: ClassVar = [
-        limiter.limit("10/second", on_breach=ratelimit_error_responder)
+        limiter.limit("30/second", on_breach=ratelimit_error_responder)
     ]
 
     @staticmethod
@@ -163,7 +163,7 @@ class MetGetCheckRequest(Resource):
     """
 
     decorators: ClassVar = [
-        limiter.limit("10/second", on_breach=ratelimit_error_responder)
+        limiter.limit("30/second", on_breach=ratelimit_error_responder)
     ]
 
     @staticmethod
@@ -193,7 +193,7 @@ class MetGetTrack(Resource):
     """
 
     decorators: ClassVar = [
-        limiter.limit("10/second", on_breach=ratelimit_error_responder)
+        limiter.limit("30/second", on_breach=ratelimit_error_responder)
     ]
 
     @staticmethod


### PR DESCRIPTION
## Check for Grib2 Index
MetGet could report that data was available when NOAA had not yet uploaded the index file for the data. This could cause MetGet to fail. While a subsequent call to MetGet would be successful, this isn't the desired behavior. Now, we'll check for the `*.idx` file when marking files as available. This will probably be slower for high volume providers (i.e. GEFS) and we may want to consider disabling it for specific providers who are well behaved since this tends to only be an issue for HRRR. 