### PR TITLE
Adding capability to return all variables for COAMPS-TC

### DIFF
--- a/containers/keymanager/start_keymanager.sh
+++ b/containers/keymanager/start_keymanager.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-if [[ $# -lt 2 ]] ; then
+if [[ $# -ne 1 ]] ; then
     echo "[ERROR]: Not enough arguments supplied"
     echo "Usage:"
-    echo "./start_metget_keymanager.sh [namespace] [prefix]"
+    echo "./start_metget_keymanager.sh [namespace]"
     exit 1
 fi
 
 namespace=$1
 prefix=$2
-pod_name=$(kubectl get pods -l=app=$2-keymanager -n $1 --no-headers | cut -d" " -f1)
+pod_name=$(kubectl get pods -l=app=keymanager -n $1 --no-headers | cut -d" " -f1)
 
-echo "[INFO]: Starting key manager in namespace: $1 with prefix: $2 (pod: $pod_name)"
+echo "[INFO]: Starting key manager in namespace: $1 (pod: $pod_name)"
 kubectl -n $1 exec -it $pod_name -- /bin/bash

--- a/containers/rebuild/start_rebuilder.sh
+++ b/containers/rebuild/start_rebuilder.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
-if [[ $# -lt 2 ]] ; then
+if [[ $# -ne 1 ]] ; then
     echo "[ERROR]: Not enough arguments supplied"
     echo "Usage:"
-    echo "./start_metget_rebuild.sh [namespace] [prefix]"
+    echo "./start_metget_rebuild.sh [namespace]"
     exit 1
 fi
 
 namespace=$1
-prefix=$2
-pod_name=$(kubectl get pods -l=app=$2-rebuild -n $1 --no-headers | cut -d" " -f1)
+pod_name=$(kubectl get pods -l=app=rebuild -n $1 --no-headers | cut -d" " -f1)
 
-echo "[INFO]: Starting key manager in namespace: $1 with prefix: $2 (pod: $pod_name)"
+echo "[INFO]: Starting key manager in namespace: $1 (pod: $pod_name)"
 kubectl -n $1 exec -it $pod_name -- /bin/bash

--- a/helm/metget-server/templates/api.yaml
+++ b/helm/metget-server/templates/api.yaml
@@ -1,24 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-api
+  name: api
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}-api
+    app.kubernetes.io/name: api
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}-api
+      app.kubernetes.io/name: api
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Release.Name }}-api
+        app.kubernetes.io/name: api
     spec:
       terminationGracePeriodSeconds: 5
       containers:
       - image: {{ .Values.containers.api.image }}:{{ .Values.containers.version }}
         imagePullPolicy: Always
-        name: {{ .Release.Name }}-api
+        name: api
         resources:
           requests:
             memory: 1Gi
@@ -40,42 +40,42 @@ spec:
         - name: METGET_DATABASE_USER
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-database-secret
+              name: database-secret
               key: username
         - name: METGET_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-database-secret
+              name: database-secret
               key: password
         - name: METGET_DATABASE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.name
         - name: METGET_REQUEST_TABLE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.request_table
         - name: METGET_API_KEY_TABLE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.apikey_table
         - name: METGET_S3_BUCKET
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: s3.storage_bucket
         - name: METGET_S3_BUCKET_UPLOAD
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: s3.upload_bucket
         - name: METGET_RABBITMQ_QUEUE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: rabbit.queue
         - name: METGET_ENFORCE_CREDIT_LIMITS
           {{ if .Values.config.credits.enforce_credit_limits }}
@@ -91,9 +91,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-api
+  name: api
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}-api
+    app.kubernetes.io/name: api
 spec:
   type: NodePort
   ports:
@@ -101,4 +101,4 @@ spec:
       targetPort: api-port
       protocol: TCP
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}-api
+    app.kubernetes.io/name: api

--- a/helm/metget-server/templates/argo/operate-workflow-sa.yaml
+++ b/helm/metget-server/templates/argo/operate-workflow-sa.yaml
@@ -18,6 +18,21 @@ rules:
       - workflowtemplates
       - cronworkflows
       - clusterworkflowtemplates
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/metget-server/templates/build/argo-event-sensor-amqp.yaml
+++ b/helm/metget-server/templates/build/argo-event-sensor-amqp.yaml
@@ -1,17 +1,17 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: {{ .Release.Name }}-build-sensor
+  name: build-sensor
 spec:
+  dependencies:
+    - name: build-dependency
+      eventSourceName: build-source
+      eventName: queue-source
   template:
     serviceAccountName: operate-workflow-sa
-  dependencies:
-    - name: {{ .Release.Name }}-build-dependency
-      eventSourceName: {{ .Release.Name }}-build-source
-      eventName: {{ .Release.Name }}-queue-source
   triggers:
     - template:
-        name: {{ .Release.Name }}-build-workflow
+        name: build-workflow
         k8s:
           operation: create
           source:
@@ -19,16 +19,21 @@ spec:
               apiVersion: argoproj.io/v1alpha1
               kind: Workflow
               metadata:
-                generateName: {{ .Release.Name }}-build-
+                generateName: build-
               spec:
-                entrypoint: {{ .Release.Name }}-build
+                entrypoint: build
+                serviceAccountName: operate-workflow-sa
+                ttlStrategy:
+                  secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+                  secondsAfterSuccess: 120       # Time to live after workflow is successful
+                  secondsAfterFailure: 86400     # Time to live after workflow fails
                 arguments:
                   parameters:
                     - name: message
                       # value will get overridden by the event payload
                       value: hello world
                 templates:
-                  - name: {{ .Release.Name }}-build
+                  - name: build
                     inputs:
                       parameters:
                         - name: message
@@ -39,12 +44,12 @@ spec:
                         - name: METGET_DATABASE_USER
                           valueFrom:
                             secretKeyRef:
-                              name: {{ .Release.Name }}-database-secret
+                              name: database-secret
                               key: username
                         - name: METGET_DATABASE_PASSWORD
                           valueFrom:
                             secretKeyRef:
-                              name: {{ .Release.Name }}-database-secret
+                              name: database-secret
                               key: password
                         - name: AWS_ACCESS_KEY_ID
                           valueFrom:
@@ -64,32 +69,32 @@ spec:
                         - name: METGET_DATABASE
                           valueFrom:
                             configMapKeyRef:
-                              name: {{ .Release.Name }}-configmap
+                              name: configmap
                               key: database.name
                         - name: METGET_REQUEST_TABLE
                           valueFrom:
                             configMapKeyRef:
-                              name: {{ .Release.Name }}-configmap
+                              name: configmap
                               key: database.request_table
                         - name: METGET_API_KEY_TABLE
                           valueFrom:
                             configMapKeyRef:
-                              name: {{ .Release.Name }}-configmap
+                              name: configmap
                               key: database.apikey_table
                         - name: METGET_S3_BUCKET
                           valueFrom:
                             configMapKeyRef:
-                              name: {{ .Release.Name }}-configmap
+                              name: configmap
                               key: s3.storage_bucket
                         - name: METGET_S3_BUCKET_UPLOAD
                           valueFrom:
                             configMapKeyRef:
-                              name: {{ .Release.Name }}-configmap
+                              name: configmap
                               key: s3.upload_bucket
                         - name: METGET_RABBITMQ_QUEUE
                           valueFrom:
                             configMapKeyRef:
-                              name: {{ .Release.Name }}-configmap
+                              name: configmap
                               key: rabbit.queue
                         - name: METGET_REQUEST_JSON
                           value: '{{ "{{" }}inputs.parameters.message{{ "}}" }}'
@@ -103,6 +108,6 @@ spec:
                           ephemeral-storage: 8Gi
           parameters:
             - src:
-                dependencyName: {{ .Release.Name }}-build-dependency
+                dependencyName: build-dependency
                 dataKey: body
               dest: spec.arguments.parameters.0.value

--- a/helm/metget-server/templates/build/argo-event-source-amqp.yaml
+++ b/helm/metget-server/templates/build/argo-event-source-amqp.yaml
@@ -1,12 +1,12 @@
 apiVersion: argoproj.io/v1alpha1
 kind: EventSource
 metadata:
-  name: {{ .Release.Name }}-build-source
+  name: build-source
 spec:
   amqp:
-    {{ .Release.Name }}-queue-source:
+    queue-source:
       # amqp server url
-      url: amqp://metget-rabbitmq-service.{{ .Release.Namespace }}:5672
+      url: amqp://rabbitmq.{{ .Release.Namespace }}:5672
       # jsonBody specifies that all event body payload coming from this
       # source will be JSON
       jsonBody: true

--- a/helm/metget-server/templates/configmap.yaml
+++ b/helm/metget-server/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-configmap
+  name: configmap
 data:
   database.name: metget
   database.request_table: requests

--- a/helm/metget-server/templates/database.yaml
+++ b/helm/metget-server/templates/database.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Release.Name }}-database-pv-claim
+  name: database-pv-claim
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: ebs-sc
+  storageClassName: gp3
   resources:
     requests:
       storage: 20Gi
@@ -14,7 +14,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Release.Name }}-database-pv-volume
+  name: database-pv-volume
   labels:
     type: local
 spec:
@@ -29,7 +29,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Release.Name }}-database-pv-claim
+  name: database-pv-claim
 spec:
   storageClassName: manual
   accessModes:
@@ -42,22 +42,22 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-database
+  name: database
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-database
+      app: database
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-database
+        app: database
     spec:
       terminationGracePeriodSeconds: 5
       containers:
       - image: {{ .Values.containers.database.image }}:{{ .Values.containers.version }}
         imagePullPolicy: Always
-        name: {{ .Release.Name }}-database
+        name: database
         resources:
           requests:
             memory: 4Gi
@@ -83,12 +83,12 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-database-secret
+              name: database-secret
               key: password
         - name: POSTGRES_DB
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.name
         - name: PGDATA
           value: /var/lib/postgresql/data/database-data
@@ -96,30 +96,30 @@ spec:
         - containerPort: 5432
           name: db-port
         volumeMounts:
-        - name: {{ .Release.Name }}-database-persistent-storage
+        - name: database-persistent-storage
           mountPath: /var/lib/postgresql/data
       volumes:
-      - name: {{ .Release.Name }}-database-persistent-storage
+      - name: database-persistent-storage
         persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-database-pv-claim
+          claimName: database-pv-claim
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: metget-database
+  name: database
   labels:
-    app: {{ .Release.Name }}-database
+    app: database
 spec:
   type: ClusterIP
   ports:
   - port: 5432
   selector:
-    app: {{ .Release.Name }}-database
+    app: database
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-database-secret
+  name: database-secret
 type: kubernetes.io/basic-auth
 stringData:
   username: postgres

--- a/helm/metget-server/templates/download/metget_download_workflow_coamps.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_coamps.yaml
@@ -8,6 +8,11 @@ spec:
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
   workflowSpec:
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     entrypoint: runner
     arguments:
       parameters:
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/download/metget_download_workflow_ctcx.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_ctcx.yaml
@@ -9,6 +9,11 @@ spec:
   startingDeadlineSeconds: 0
   workflowSpec:
     entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     arguments:
       parameters:
         - name: input-service
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/download/metget_download_workflow_era5.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_era5.yaml
@@ -9,6 +9,11 @@ spec:
   startingDeadlineSeconds: 0
   workflowSpec:
     entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     arguments:
       parameters:
         - name: input-service
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/download/metget_download_workflow_gefs.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_gefs.yaml
@@ -9,6 +9,11 @@ spec:
   startingDeadlineSeconds: 0
   workflowSpec:
     entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     arguments:
       parameters:
         - name: input-service
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/download/metget_download_workflow_gfs.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_gfs.yaml
@@ -9,6 +9,11 @@ spec:
   startingDeadlineSeconds: 0
   workflowSpec:
     entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     arguments:
       parameters:
         - name: input-service
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/download/metget_download_workflow_hafs.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_hafs.yaml
@@ -9,6 +9,11 @@ spec:
   startingDeadlineSeconds: 0
   workflowSpec:
     entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     arguments:
       parameters:
         - name: input-service
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/download/metget_download_workflow_hrrr-alaska.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_hrrr-alaska.yaml
@@ -9,6 +9,11 @@ spec:
   startingDeadlineSeconds: 0
   workflowSpec:
     entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     arguments:
       parameters:
         - name: input-service
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/download/metget_download_workflow_hrrr.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_hrrr.yaml
@@ -9,6 +9,11 @@ spec:
   startingDeadlineSeconds: 0
   workflowSpec:
     entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     arguments:
       parameters:
         - name: input-service
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/download/metget_download_workflow_hwrf.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_hwrf.yaml
@@ -9,6 +9,11 @@ spec:
   startingDeadlineSeconds: 0
   workflowSpec:
     entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     arguments:
       parameters:
         - name: input-service
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/download/metget_download_workflow_nam.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_nam.yaml
@@ -9,6 +9,11 @@ spec:
   startingDeadlineSeconds: 0
   workflowSpec:
     entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     arguments:
       parameters:
         - name: input-service
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/download/metget_download_workflow_nhc.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_nhc.yaml
@@ -9,6 +9,11 @@ spec:
   startingDeadlineSeconds: 0
   workflowSpec:
     entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     arguments:
       parameters:
         - name: input-service
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/download/metget_download_workflow_template.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_template.yaml
@@ -1,11 +1,11 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: {{ .Release.Name }}-download-template
+  name: download-template
 spec:
-  entrypoint: {{ .Release.Name }}-download-runner
+  entrypoint: download-runner
   templates:
-  - name: {{ .Release.Name }}-download-runner
+  - name: download-runner
     inputs:
       parameters:
         - name: service
@@ -23,27 +23,27 @@ spec:
         - name: METGET_DATABASE_USER
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-database-secret
+              name: database-secret
               key: username
         - name: METGET_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-database-secret
+              name: database-secret
               key: password
         - name: METGET_DATABASE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.name
         - name: METGET_REQUEST_TABLE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.request_table
         - name: METGET_API_KEY_TABLE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.apikey_table
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
@@ -63,7 +63,7 @@ spec:
         - name: METGET_S3_BUCKET
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: s3.storage_bucket
         - name: COAMPS_S3_BUCKET
           value: {{ .Values.s3.coamps_storage_bucket }}

--- a/helm/metget-server/templates/download/metget_download_workflow_wpc.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_wpc.yaml
@@ -9,6 +9,11 @@ spec:
   startingDeadlineSeconds: 0
   workflowSpec:
     entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
     arguments:
       parameters:
         - name: input-service
@@ -18,8 +23,8 @@ spec:
         steps:
         - - name: download
             templateRef:
-              name: {{ .Release.Name }}-download-template
-              template: {{ .Release.Name }}-download-runner
+              name: download-template
+              template: download-runner
             arguments:
               parameters:
                 - name: service

--- a/helm/metget-server/templates/ingress.yaml
+++ b/helm/metget-server/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-ingress
+  name: ingress
   annotations:
     alb.ingress.kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/load-balancer-name: {{ .Release.Name }}-ingress
@@ -28,11 +28,11 @@ spec:
           pathType: ImplementationSpecific
           backend:
             service:
-              name: {{ .Release.Name }}-api
+              name: api
               port:
                 number: 80
 
   tls:
     - hosts:
        - {{ .Values.http.host }}
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/keymanager.yaml
+++ b/helm/metget-server/templates/keymanager.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-keymanager
+  name: keymanager
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-keymanager
+      app: keymanager
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-keymanager
+        app: keymanager
     spec:
       terminationGracePeriodSeconds: 5
       containers:
       - image: {{ .Values.containers.key_manager.image }}:{{ .Values.containers.version }}
         imagePullPolicy: Always
-        name: {{ .Release.Name }}-keymanager
+        name: keymanager
         resources:
           requests:
             memory: 1Gi
@@ -29,25 +29,25 @@ spec:
         - name: METGET_DATABASE_USER
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-database-secret
+              name: database-secret
               key: username
         - name: METGET_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-database-secret
+              name: database-secret
               key: password
         - name: METGET_DATABASE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.name
         - name: METGET_REQUEST_TABLE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.request_table
         - name: METGET_API_KEY_TABLE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.apikey_table

--- a/helm/metget-server/templates/rabbitmq.yaml
+++ b/helm/metget-server/templates/rabbitmq.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     component: rabbitmq
-  name: {{ .Release.Name }}-rabbitmq-controller
+  name: rabbitmq-controller
 spec:
   replicas: 1
   selector:
@@ -32,7 +32,7 @@ kind: Service
 metadata:
   labels:
     component: rabbitmq
-  name: metget-rabbitmq-service
+  name: rabbitmq
 spec:
   type: ClusterIP
   ports:

--- a/helm/metget-server/templates/rebuild.yaml
+++ b/helm/metget-server/templates/rebuild.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-rebuild
+  name: rebuild
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-rebuild
+      app: rebuild
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-rebuild
+        app: rebuild
     spec:
       terminationGracePeriodSeconds: 5
       containers:
       - image: {{ .Values.containers.rebuild.image }}:{{ .Values.containers.version }}
         imagePullPolicy: Always
-        name: {{ .Release.Name }}-rebuild
+        name: rebuild
         resources:
           requests:
             memory: 1Gi
@@ -29,27 +29,27 @@ spec:
         - name: METGET_DATABASE_USER
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-database-secret
+              name: database-secret
               key: username
         - name: METGET_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-database-secret
+              name: database-secret
               key: password
         - name: METGET_DATABASE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.name
         - name: METGET_REQUEST_TABLE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.request_table
         - name: METGET_API_KEY_TABLE
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: database.apikey_table
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
@@ -69,7 +69,7 @@ spec:
         - name: METGET_S3_BUCKET
           valueFrom:
             configMapKeyRef:
-              name: {{ .Release.Name }}-configmap
+              name: configmap
               key: s3.storage_bucket
         - name: COAMPS_S3_BUCKET
           value: {{ .Values.s3.coamps_storage_bucket }}

--- a/src/executables/api/src/metget_api/build_request.py
+++ b/src/executables/api/src/metget_api/build_request.py
@@ -114,7 +114,11 @@ class BuildRequest:
         import pika
 
         if transmit:
-            host = os.environ["METGET_RABBITMQ_SERVICE_SERVICE_HOST"]
+            # Eventually we can remove this logic completely as we transition
+            # away from environment variables and use the dns instead, which
+            # is more resilient
+            host = os.environ.get("METGET_RABBITMQ_SERVICE_SERVICE_HOST", "rabbitmq")
+
             queue = os.environ["METGET_RABBITMQ_QUEUE"]
             params = pika.ConnectionParameters(host, 5672)
             connection = pika.BlockingConnection(params)

--- a/src/executables/rebuild/src/metget_rebuild/rebuild.py
+++ b/src/executables/rebuild/src/metget_rebuild/rebuild.py
@@ -149,7 +149,7 @@ def rebuild_coamps(start: datetime, end: datetime) -> int:
 
     logger = logging.getLogger(__name__)
 
-    if "COAMPS_S3_BUCKET" in os.environ:
+    if "COAMPS_S3_BUCKET" not in os.environ:
         msg = "Environment variable 'COAMPS_S3_BUCKET' not set"
         raise ValueError(msg)
 
@@ -169,7 +169,7 @@ def rebuild_ctcx(start: datetime, end: datetime) -> int:
 
     logger = logging.getLogger(__name__)
 
-    if "COAMPS_S3_BUCKET" in os.environ:
+    if "COAMPS_S3_BUCKET" not in os.environ:
         msg = "Environment variable 'COAMPS_S3_BUCKET' not set"
         raise ValueError(msg)
 
@@ -357,10 +357,10 @@ def nhc_download_data(table) -> int:  # noqa: PLR0915
         for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
             if "Contents" in page:
                 for obj in page["Contents"]:
-                    keys = obj["Key"].split("/")[2].split("_")
-
-                    storm_year = keys[2]
+                    storm_year = obj["Key"].split("/")[2]
+                    keys = obj["Key"].split("/")[3].split("_")
                     basin = keys[3]
+
                     if table == NhcBtkTable:
                         storm_id = int(keys[4].split(".")[0])
                         advisory = None
@@ -467,7 +467,6 @@ def check_for_environment_variables():
     import os
 
     required_env_vars = [
-        "METGET_DATABASE_SERVICE_HOST",
         "METGET_DATABASE_USER",
         "METGET_DATABASE_PASSWORD",
         "METGET_DATABASE",

--- a/src/libraries/libmetget/src/libmetget/build/datainterpolator.py
+++ b/src/libraries/libmetget/src/libmetget/build/datainterpolator.py
@@ -201,6 +201,9 @@ class DataInterpolator:
         """
         variable_list = variable_type.select()
         for var in variable_list:
+            if str(var) not in data:
+                continue
+
             if self.__backfill_flag and self.__domain_level != 0:
                 default_value = var.fill_value()
             else:

--- a/src/libraries/libmetget/src/libmetget/build/domain.py
+++ b/src/libraries/libmetget/src/libmetget/build/domain.py
@@ -31,6 +31,8 @@ import logging
 
 from .output.outputgrid import OutputGrid
 
+log = logging.getLogger(__name__)
+
 VALID_SERVICES = [
     "gfs-ncep",
     "gefs-ncep",
@@ -64,8 +66,6 @@ class Domain:
         """
         from .output.gridfactory import grid_factory
 
-        log = logging.getLogger(__name__)
-
         self.__valid = True
         self.__name = name
         self.__service = service
@@ -74,18 +74,25 @@ class Domain:
         self.__storm_year = None
         self.__tau = None
         self.__domain_level = domain_level
+
         if self.__service not in VALID_SERVICES:
-            log.warning(
-                f"Domain invalid because {self.__service:s} is not a valid service"
+            log.error(
+                f"Domain {domain_level} invalid because {self.__service:s} is not a valid service"
             )
             self.__valid = False
+            return
+
         self.__json = json
+
         try:
             self.__grid = grid_factory(self.__json)
         except Exception as e:
-            log.warning(f"Domain invalid because exception was thrown: {e!s:s}")
+            log.error(
+                f"Domain {domain_level} invalid because exception was thrown: {e!s:s}"
+            )
             self.__valid = False
-            raise
+            return
+
         self.__storm = None
         self.__get_storm()
         self.__get_basin()

--- a/src/libraries/libmetget/src/libmetget/build/output/netcdfdomain.py
+++ b/src/libraries/libmetget/src/libmetget/build/output/netcdfdomain.py
@@ -248,6 +248,7 @@ class NetcdfDomain(OutputDomain):
         )
 
         for v in variables:
-            self.__dataset.variables[v.netcdf_var_name()][index, :, :] = dataset[
-                str(v)
-            ].to_numpy()
+            if str(v) in dataset:
+                self.__dataset.variables[v.netcdf_var_name()][index, :, :] = dataset[
+                    str(v)
+                ].to_numpy()

--- a/src/libraries/libmetget/src/libmetget/database/database.py
+++ b/src/libraries/libmetget/src/libmetget/database/database.py
@@ -97,16 +97,13 @@ class Database:
         log = logging.getLogger(__name__)
 
         if (
-            "METGET_DATABASE_SERVICE_HOST" not in os.environ
-            or "METGET_DATABASE_PASSWORD" not in os.environ
+            "METGET_DATABASE_PASSWORD" not in os.environ
             or "METGET_DATABASE_USER" not in os.environ
             or "METGET_DATABASE" not in os.environ
         ):
             # List the environment variables that are required for the database
             # connection
             log.error("Database environment variables not set")
-            if "METGET_DATABASE_SERVICE_HOST" not in os.environ:
-                log.error("METGET_DATABASE_SERVICE_HOST not set")
             if "METGET_DATABASE_PASSWORD" not in os.environ:
                 log.error("METGET_DATABASE_PASSWORD not set")
             if "METGET_DATABASE_USER" not in os.environ:
@@ -117,7 +114,10 @@ class Database:
             msg = "Database environment variables not set"
             raise RuntimeError(msg)
 
-        db_host = os.environ["METGET_DATABASE_SERVICE_HOST"]
+        # We can remove this altogether later as we will transition
+        # to using the dns names fully
+        db_host = os.environ.get("METGET_DATABASE_SERVICE_HOST", "database")
+
         db_password = os.environ["METGET_DATABASE_PASSWORD"]
         db_username = os.environ["METGET_DATABASE_USER"]
         db_name = os.environ["METGET_DATABASE"]

--- a/src/libraries/libmetget/src/libmetget/download/hwrfdownloader.py
+++ b/src/libraries/libmetget/src/libmetget/download/hwrfdownloader.py
@@ -65,7 +65,7 @@ class HwrfDownloader(NoaaDownloader):
                             files.append(lll)
         pairs = self.generateGrbInvPairs(files)
         for p in pairs:
-            fpath, n, _ = self.get_grib(p, p["cycledate"])
+            fpath, n, _ = self.get_grib(p)
             if fpath:
                 db.add(p, self.met_type(), fpath)
                 num_download = num_download + n

--- a/src/libraries/libmetget/src/libmetget/download/nhcdata.py
+++ b/src/libraries/libmetget/src/libmetget/download/nhcdata.py
@@ -1,0 +1,383 @@
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, List
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class NhcLine:
+    """
+    A class to represent a line from the NHC file
+    """
+
+    line: str
+    basin: str = field(init=False)
+    cyclone_number: int = field(init=False)
+    cycle_date: datetime = field(init=False)
+    technique_number: str = field(init=False)
+    technique: str = field(init=False)
+    forecast_hour: int = field(init=False)
+    latitude: float = field(init=False)
+    longitude: float = field(init=False)
+    maximum_sustained_wind: int = field(init=False)
+    minimum_pressure: int = field(init=False)
+    development_level: str = field(init=False)
+    radii_for_record: float = field(init=False)
+    wind_code: str = field(init=False)
+    radius_1: float = field(init=False)
+    radius_2: float = field(init=False)
+    radius_3: float = field(init=False)
+    radius_4: float = field(init=False)
+    last_closed_isobar: float = field(init=False)
+    last_closed_isobar_radius: float = field(init=False)
+    radius_to_max_winds: float = field(init=False)
+    gusts: float = field(init=False)
+    eye_diameter: float = field(init=False)
+    subregion: str = field(init=False)
+    maximum_seas: float = field(init=False)
+    forecaster_initials: str = field(init=False)
+    storm_direction: float = field(init=False)
+    storm_speed: float = field(init=False)
+    storm_name: str = field(init=False)
+    system_depth: str = field(init=False)
+    seas_wave_height: float = field(init=False)
+    seas_radius_code: str = field(init=False)
+    seas_1: float = field(init=False)
+    seas_2: float = field(init=False)
+    seas_3: float = field(init=False)
+    seas_4: float = field(init=False)
+
+    def __post_init__(self):
+        """
+        Parse the NHC line which is in ATCF format
+        """
+        self.__set_default_values()
+
+        string_split = self.line.strip().split(",")
+
+        self.basin = string_split[0].strip()
+        self.cyclone_number = int(string_split[1].strip())
+        self.cycle_date = datetime.strptime(string_split[2].strip(), "%Y%m%d%H")
+        self.technique_number = string_split[3].strip()
+        self.technique = string_split[4].strip()
+        self.forecast_hour = int(string_split[5].strip())
+        self.latitude = (
+            float(string_split[6][:-1].strip()) / 10
+            if "N" in string_split[6]
+            else -float(string_split[6][:-1].strip()) / 10
+        )
+        self.longitude = (
+            float(string_split[7][:-1].strip()) / 10
+            if "E" in string_split[7]
+            else -float(string_split[7][:-1].strip()) / 10
+        )
+        self.maximum_sustained_wind = int(string_split[8].strip())
+        self.minimum_pressure = int(string_split[9].strip())
+        self.development_level = string_split[10].strip()
+        self.radii_for_record = float(string_split[11].strip())
+        self.wind_code = string_split[12].strip()
+        try:
+            self.radius_1 = NhcLine.__parse_as_type(string_split[13].strip(), float)
+            self.radius_2 = NhcLine.__parse_as_type(string_split[14].strip(), float)
+            self.radius_3 = NhcLine.__parse_as_type(string_split[15].strip(), float)
+            self.radius_4 = NhcLine.__parse_as_type(string_split[16].strip(), float)
+            self.last_closed_isobar = NhcLine.__parse_as_type(
+                string_split[17].strip(), float
+            )
+            self.last_closed_isobar_radius = NhcLine.__parse_as_type(
+                string_split[18].strip(), float
+            )
+            self.radius_to_max_winds = NhcLine.__parse_as_type(
+                string_split[19].strip(), float
+            )
+            self.gusts = NhcLine.__parse_as_type(string_split[20].strip(), float)
+            self.eye_diameter = NhcLine.__parse_as_type(string_split[21].strip(), float)
+            self.subregion = string_split[22].strip()
+            self.maximum_seas = NhcLine.__parse_as_type(string_split[23].strip(), float)
+            self.forecaster_initials = string_split[24].strip()
+            self.storm_direction = NhcLine.__parse_as_type(
+                string_split[25].strip(), float
+            )
+            self.storm_speed = NhcLine.__parse_as_type(string_split[26].strip(), float)
+            self.storm_name = string_split[27].strip()
+            self.system_depth = string_split[28].strip()
+            self.seas_wave_height = NhcLine.__parse_as_type(
+                string_split[29].strip(), float
+            )
+            self.seas_radius_code = string_split[30].strip()
+            self.seas_1 = NhcLine.__parse_as_type(string_split[31].strip(), float)
+            self.seas_2 = NhcLine.__parse_as_type(string_split[32].strip(), float)
+            self.seas_3 = NhcLine.__parse_as_type(string_split[33].strip(), float)
+            self.seas_4 = NhcLine.__parse_as_type(string_split[34].strip(), float)
+        except IndexError:
+            pass
+
+    @staticmethod
+    def __parse_as_type(value: str, as_type: type) -> Any:
+        """
+        Parse a value as a specific type
+
+        Args:
+            value: The value to parse
+            as_type: The type to parse the value as
+
+        Returns:
+            The parsed value as the specified type or None if the value cannot be parsed
+        """
+        try:
+            return as_type(value)
+        except ValueError:
+            return as_type(0)
+
+    def __set_default_values(self) -> None:
+        """
+        Set default values for the NHC line
+        """
+        self.basin = ""
+        self.cyclone_number = 0
+        self.cycle_date = datetime.now()
+        self.technique_number = ""
+        self.technique = ""
+        self.forecast_hour = 0
+        self.latitude = 0.0
+        self.longitude = 0.0
+        self.maximum_sustained_wind = 0
+        self.minimum_pressure = 0
+        self.development_level = ""
+        self.radii_for_record = 0.0
+        self.wind_code = ""
+        self.radius_1 = 0.0
+        self.radius_2 = 0.0
+        self.radius_3 = 0.0
+        self.radius_4 = 0.0
+        self.last_closed_isobar = 0.0
+        self.last_closed_isobar_radius = 0.0
+        self.radius_to_max_winds = 0.0
+        self.gusts = 0.0
+        self.eye_diameter = 0.0
+        self.subregion = ""
+        self.maximum_seas = 0.0
+        self.forecaster_initials = ""
+        self.storm_direction = 0.0
+        self.storm_speed = 0.0
+        self.storm_name = ""
+        self.system_depth = ""
+        self.seas_wave_height = 0.0
+        self.seas_radius_code = ""
+        self.seas_1 = 0.0
+        self.seas_2 = 0.0
+        self.seas_3 = 0.0
+        self.seas_4 = 0.0
+
+    def __str__(self) -> str:
+        """
+        Write the data back as a string as it was found in the ATCF file
+        """
+        lon = (
+            f"{abs(self.longitude*10):4.0f}W"
+            if self.longitude < 0
+            else f"{abs(self.longitude*10):4.0f}E"
+        )
+        lat = (
+            f"{abs(self.latitude*10):4.0f}S"
+            if self.latitude < 0
+            else f"{abs(self.latitude*10):4.0f}N"
+        )
+
+        return (
+            f"{self.basin}, {self.cyclone_number:02d}, {self.cycle_date.strftime('%Y%m%d%H')},"
+            f"{self.technique_number:>3s},{self.technique:>5s},{self.forecast_hour:4d},"
+            f"{lat:>5s},{lon:>6s},{self.maximum_sustained_wind:4.0f},"
+            f"{self.minimum_pressure:5.0f},{self.development_level:>3s},{self.radii_for_record:4.0f},"
+            f"{self.wind_code:>4s},{self.radius_1:5.0f},{self.radius_2:5.0f},{self.radius_3:5.0f},"
+            f"{self.radius_4:5.0f},{self.last_closed_isobar:5.0f},{self.last_closed_isobar_radius:5.0f},"
+            f"{self.radius_to_max_winds:4.0f},{self.gusts:4.0f},{self.eye_diameter:4.0f},{self.subregion:>4s},"
+            f"{self.maximum_seas:3.0f},{self.forecaster_initials:>4s},{self.storm_direction:4.0f},"
+            f"{self.storm_speed:4.0f},{self.storm_name:>11s},{self.system_depth:>3s},{self.seas_wave_height:3.0f},"
+            f"{self.seas_radius_code:>4s},{self.seas_1:5.0f},{self.seas_2:5.0f},{self.seas_3:5.0f},{self.seas_4:5.0f}"
+        )
+
+
+class NhcProcessArchive:
+    def __init__(self, year: int, track_type: str):
+        self.__year = year
+        self.__track_type = track_type
+
+    def process(self):
+        """
+        Process the NHC archive for a specific year
+        """
+        import os
+
+        # Make the directory path
+        track_path = "besttrack" if self.__track_type == "best" else "forecast"
+        output_dir = os.path.join(track_path, str(self.__year))
+        os.makedirs(output_dir, exist_ok=True)
+
+        for file in self.__get_filelist():
+            log.info(f"Processing file {file}")
+            self.__get_file(file)
+            self.__process_file(file, output_dir)
+            os.remove(file)
+
+    def __process_file(self, filename: str, output_dir: str) -> None:
+        """
+        Process the file. Keep only the NHC (OFCL) data and write to disk
+
+        Args:
+            filename: The filename to process
+            output_dir: The output directory to write the files to
+        """
+        if self.__track_type == "forecast":
+            self.__process_file_forecast(filename, output_dir)
+        elif self.__track_type == "best":
+            self.__process_file_best(filename, output_dir)
+
+    def __process_file_best(self, filename: str, output_dir: str) -> None:
+        """
+        Process the best track file. Keep only the NHC (BEST) data and write to disk
+        """
+        import gzip
+        import os
+
+        fid = None
+        with gzip.open(filename, "rt") as f:
+            for line in f:
+                nhc_line = NhcLine(line)
+                if nhc_line.technique == "BEST":
+                    if fid is None:
+                        outfile = os.path.join(
+                            output_dir,
+                            "nhc_btk_{:d}_{:s}_{:02d}.btk".format(
+                                self.__year,
+                                nhc_line.basin.lower(),
+                                nhc_line.cyclone_number,
+                            ),
+                        )
+                        fid = open(outfile, "w")  # noqa: SIM115
+                    # fid.write(str(nhc_line) + "\n") # Are we fancy? Lets not chance it
+                    fid.write(line)
+            if fid is not None:
+                fid.close()
+
+    def __process_file_forecast(self, filename: str, output_dir: str) -> None:
+        """
+        Process the forecast file. Keep only the NHC (OFCL) data and write to disk
+
+        Args:
+            filename: The filename to process
+            output_dir: The output directory to write the files to
+        """
+        import gzip
+        import os
+
+        with gzip.open(filename, "rt") as f:
+            last_nhc_cycle_date = None
+            current_nhc_cycle_id = 0
+            fid = None
+            for line in f:
+                nhc_line = NhcLine(line)
+                if nhc_line.technique == "OFCL":
+                    if (
+                        last_nhc_cycle_date is None
+                        or nhc_line.cycle_date != last_nhc_cycle_date
+                    ):
+                        current_nhc_cycle_id += 1
+                        last_nhc_cycle_date = nhc_line.cycle_date
+                        if fid is not None:
+                            fid.close()
+                        filename = "nhc_fcst_{:d}_{:s}_{:02d}_{:03d}.fcst".format(
+                            self.__year,
+                            nhc_line.basin.lower(),
+                            nhc_line.cyclone_number,
+                            current_nhc_cycle_id,
+                        )
+                        fid = open(  # noqa: SIM115
+                            os.path.join(output_dir, filename), "w"
+                        )
+                    # fid.write(str(nhc_line) + "\n")
+                    fid.write(line)
+
+            if fid is not None:
+                fid.close()
+
+    def __get_file(self, file: str) -> None:
+        """
+        Get the file from the nhc archive ftp server
+
+        Args:
+            file: The file to get
+        """
+        import ftplib
+
+        with ftplib.FTP("ftp.nhc.noaa.gov") as ftp:
+            ftp.login()
+            ftp.cwd(f"/atcf/archive/{self.__year}")
+            with open(file, "wb") as f:
+                ftp.retrbinary(f"RETR {file}", f.write)
+
+    def __get_filelist(self) -> List[str]:
+        """
+        Get the list of *.gz files from the nhc archive
+
+        Returns:
+            The list of *.gz files
+        """
+
+        import ftplib
+
+        with ftplib.FTP("ftp.nhc.noaa.gov") as ftp:
+            ftp.login()
+            ftp.cwd(f"/atcf/archive/{self.__year}")
+            files = ftp.nlst()
+            if self.__track_type == "best":
+                return [f for f in files if f.endswith(".gz") and f.startswith("b")]
+            elif self.__track_type == "forecast":
+                return [f for f in files if f.endswith(".gz") and f.startswith("a")]
+            return None
+
+
+if __name__ == "__main__":
+    """
+    Process the NHC archive for a specific year and write to disk
+    """
+    import argparse
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Process the NHC archive for a specific year and write to disk"
+    )
+    parser.add_argument(
+        "--start-year", type=int, required=True, help="The first year to process"
+    )
+    parser.add_argument(
+        "--end-year", type=int, required=True, help="The last year to process"
+    )
+    parser.add_argument(
+        "--best", action="store_true", help="Process the best track archive"
+    )
+    parser.add_argument(
+        "--forecast", action="store_true", help="Process the forecast advisory archive"
+    )
+
+    args = parser.parse_args()
+
+    years = list(range(args.start_year, args.end_year + 1))
+
+    for year in years:
+        log.info(f"Processing year {year}")
+        if args.best:
+            log.info(f"Processing NHC best track archive for year {year}")
+            nhc_best = NhcProcessArchive(year, "best")
+            nhc_best.process()
+
+        if args.forecast:
+            log.info(f"Processing NHC forecast archive for year {year}")
+            nhc_fcst = NhcProcessArchive(year, "forecast")
+            nhc_fcst.process()

--- a/src/libraries/libmetget/src/libmetget/download/nhcdownloader.py
+++ b/src/libraries/libmetget/src/libmetget/download/nhcdownloader.py
@@ -716,9 +716,12 @@ class NhcDownloader:
                         )
 
                         if self.__use_aws:
-                            remote_path = self.mettype() + "/forecast/" + fn
+                            remote_path = os.path.join(
+                                self.mettype(), "forecast", year, fn
+                            )
                             filepath = fn
                         else:
+                            remote_path = None
                             filepath = self.__downloadlocation + "_fcst/" + fn
 
                         metadata = {
@@ -875,7 +878,7 @@ class NhcDownloader:
 
                     if self.__use_aws:
                         file_path = tempfile.gettempdir() + "/" + fn
-                        remote_path = "nhc/besttrack/" + fn
+                        remote_path = os.path.join("nhc", "besttrack", year, fn)
                     else:
                         file_path = self.mettype() + "_btk/" + fn
                         remote_path = None

--- a/src/libraries/libmetget/src/libmetget/sources/variabletype.py
+++ b/src/libraries/libmetget/src/libmetget/sources/variabletype.py
@@ -70,6 +70,8 @@ class VariableType(Enum):
             ret_value = VariableType.HUMIDITY
         elif data_type == "ice":
             ret_value = VariableType.ICE
+        elif data_type == "all_variables":
+            ret_value = VariableType.ALL_VARIABLES
         else:
             msg = f"Invalid data type: {data_type:s}"
             raise ValueError(msg)


### PR DESCRIPTION
For COAMPS-TC, request was made to allow the user to return `all_variables`. Now, `all_variables` is a valid variable selection in the API. A corresponding update will follow within the client.

Additionally, updating helm deployment for newer versions of Argo and to use DNS names instead of environment variables for robustness.