### PR TITLE
Fixing issue with floating point numbers coming from numpy.arange

### DIFF
--- a/src/libraries/libmetget/src/libmetget/build/output/outputgrid.py
+++ b/src/libraries/libmetget/src/libmetget/build/output/outputgrid.py
@@ -209,12 +209,14 @@ class OutputGrid:
             self.__x_lower_left,
             self.__x_upper_right + self.__x_resolution,
             self.__x_resolution,
-        )
+            dtype=np.float64,
+        ).round(11)
         y = np.arange(
             self.__y_lower_left,
             self.__y_upper_right + self.__y_resolution,
             self.__y_resolution,
-        )
+            dtype=np.float64,
+        ).round(11)
         self.__x_points = x
         self.__y_points = y
         self.__grid_points = np.array(np.meshgrid(x, y))


### PR DESCRIPTION
Fixing issue where floating point numbers were not rounded before being used in the netCDF output file

For example:
```
data:

 lon = -90, -89.95, -89.9, -89.85, -89.8, -89.75, -89.7, -89.65, -89.6,
    -89.55, -89.5, -89.45, -89.4, -89.35, -89.3, -89.25, -89.2, -89.15,
    -89.1000000000001, -89.0500000000001, -89.0000000000001,
    -88.9500000000001, -88.9000000000001, -88.8500000000001,
    -88.8000000000001, -88.7500000000001, -88.7000000000001,
    -88.6500000000001, -88.6000000000001, -88.5500000000001,
    -88.5000000000001, -88.4500000000001, -88.4000000000001,
    -88.3500000000001, -88.3000000000001, -88.2500000000001,
    -88.2000000000001, -88.1500000000001, -88.1000000000001,
    -88.0500000000001, -88.0000000000001, -87.9500000000001,
    -87.9000000000001, -87.8500000000001, -87.8000000000001,
```