### PR TITLE
Fix OWI Header format. Add fallback behavior for bad grib indexes

### DIFF
--- a/helm/metget-server/templates/download/metget_download_workflow_coamps.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_coamps.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     serviceAccountName: operate-workflow-sa
     ttlStrategy:
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_ctcx.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_ctcx.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     entrypoint: runner
     serviceAccountName: operate-workflow-sa
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_era5.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_era5.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "0 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     entrypoint: runner
     serviceAccountName: operate-workflow-sa
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_gefs.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_gefs.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     entrypoint: runner
     serviceAccountName: operate-workflow-sa
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_gfs.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_gfs.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     entrypoint: runner
     serviceAccountName: operate-workflow-sa
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_hafs.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_hafs.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     entrypoint: runner
     serviceAccountName: operate-workflow-sa
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_hrrr-alaska.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_hrrr-alaska.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     entrypoint: runner
     serviceAccountName: operate-workflow-sa
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_hrrr.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_hrrr.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     entrypoint: runner
     serviceAccountName: operate-workflow-sa
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_hwrf.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_hwrf.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     entrypoint: runner
     serviceAccountName: operate-workflow-sa
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_nam.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_nam.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     entrypoint: runner
     serviceAccountName: operate-workflow-sa
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_nhc.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_nhc.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     entrypoint: runner
     serviceAccountName: operate-workflow-sa
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_wpc.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_wpc.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
   workflowSpec:
     entrypoint: runner
     serviceAccountName: operate-workflow-sa
@@ -29,4 +30,4 @@ spec:
               parameters:
                 - name: service
                   value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
-  {{ end }}
+{{ end }}

--- a/src/libraries/libmetget/src/libmetget/build/output/owiasciidomain.py
+++ b/src/libraries/libmetget/src/libmetget/build/output/owiasciidomain.py
@@ -294,17 +294,21 @@ class OwiAsciiDomain(OutputDomain):
 
         keys = variable_type.select()
 
+        time = kwargs.get("time")
+        if time is None:
+            msg = "Time must be provided"
+            raise ValueError(msg)
+        elif not isinstance(time, datetime):
+            msg = "Time must be of type datetime"
+            raise TypeError(msg)
+
         if isinstance(self.fid(), (TextIO, io.TextIOWrapper)):
             if isinstance(self.fid(), list):
                 fid = self.fid()[0]
             else:
                 fid = self.fid()
 
-            fid.write(
-                OwiAsciiDomain.__generate_record_header(
-                    self.start_date(), self.grid_obj()
-                )
-            )
+            fid.write(OwiAsciiDomain.__generate_record_header(time, self.grid_obj()))
             OwiAsciiDomain.__write_record(fid, data[str(keys[0])].to_numpy())
         elif isinstance(self.fid(), list):
             # ...Handle the special case for a pack of 2 files (pressure and wind-u/v)
@@ -316,9 +320,7 @@ class OwiAsciiDomain(OutputDomain):
                 msg = "Only 2 files are supported for wind pressure"
                 raise ValueError(msg)
 
-            header = OwiAsciiDomain.__generate_record_header(
-                self.start_date(), self.grid_obj()
-            )
+            header = OwiAsciiDomain.__generate_record_header(time, self.grid_obj())
             self.fid()[0].write(header)
             OwiAsciiDomain.__write_record(
                 self.fid()[0], data[str(MetDataType.PRESSURE)].to_numpy()


### PR DESCRIPTION
## Fix OWI header format
The time stamp in each time step was repeated as the start time. This has no practical impact to simulations since ADCIRC does not use this information

## Add deadline seconds to download tasks
This ensures that tasks do not spin endlessly when there is a janky http connection left open by the remote server

## Download full file as fallback
When the grid inventories are malformed, fall back to just downloading the whole file and letting xarray deal with the larger data