### PR TITLE
Fix zero length WPC files

### DIFF
--- a/src/libraries/libmetget/src/libmetget/download/wpcdownloader.py
+++ b/src/libraries/libmetget/src/libmetget/download/wpcdownloader.py
@@ -115,10 +115,15 @@ class WpcDownloader:
                         )
                         ftp = WpcDownloader.__initialize_ftp(ftp_address, ftp_folder)
 
-                s3.upload_file(temp_file_path, remote_path)
-                db.add(data_pair, "wpc_ncep", remote_path)
-                os.remove(temp_file_path)
-                num_downloads += 1
+                # If the file exists on disk and the size is greater than 0, upload it to S3 and add it to the database
+                if (
+                    os.path.exists(temp_file_path)
+                    and os.path.getsize(temp_file_path) > 0
+                ):
+                    s3.upload_file(temp_file_path, remote_path)
+                    db.add(data_pair, "wpc_ncep", remote_path)
+                    os.remove(temp_file_path)
+                    num_downloads += 1
 
         return num_downloads
 

--- a/src/libraries/libmetget/src/libmetget/sources/metfiletype.py
+++ b/src/libraries/libmetget/src/libmetget/sources/metfiletype.py
@@ -395,7 +395,7 @@ NCEP_HWRF = MetFileAttributes(
 )
 
 NCEP_WPC = MetFileAttributes(
-    name="WPC",
+    name="wpc-ncep",
     table="wpc_ncep",
     table_obj=WpcTable,
     file_format=MetFileFormat.GRIB,
@@ -405,8 +405,8 @@ NCEP_WPC = MetFileAttributes(
             "type": MetDataType.PRECIPITATION,
             "name": "accumulated_precip",
             "long_name": "APCP",
-            "var_name": "apcp",
-            "grib_name": "apcp",
+            "var_name": "tp",
+            "grib_name": "tp",
             "scale": 1.0,
             "is_accumulated": True,
         },


### PR DESCRIPTION
Fixing issue when WPC uploads a zero length file. Files are now checked for size before adding to the database