### PR TITLE
Adding ability to query storm tracks from the NHC ADeck data

### DIFF
--- a/containers/database/schema.sql
+++ b/containers/database/schema.sql
@@ -132,6 +132,19 @@ CREATE TABLE wpc_ncep(
   url VARCHAR(256) NOT NULL,
   accessed TIMESTAMP NOT NULL
 );
+CREATE TABLE nhc_adeck(
+  id SERIAL PRIMARY KEY,
+  model CHAR(4) NOT NULL,
+  storm_year INTEGER NOT NULL,
+  basin CHAR(2) NOT NULL,
+  storm INTEGER NOT NULL,
+  forecastcycle TIMESTAMP NOT NULL,
+  start_time TIMESTAMP NOT NULL,
+  end_time TIMESTAMP NOT NULL,
+  duration INTEGER NOT NULL,
+  geometry_Data JSON NOT NULL
+);
+
 --
 --Creates tables for the storage of metget's API access
 --
@@ -178,6 +191,8 @@ CREATE INDEX ctcx_forecastcycle_idx ON ctcx USING brin (forecastcycle);
 CREATE INDEX hrrr_ncep_forecastcycle_idx ON hrrr_ncep USING brin (forecastcycle);
 CREATE INDEX hrrr_alaska_ncep_forecastcycle_idx ON hrrr_alaska_ncep USING brin (forecastcycle);
 CREATE INDEX wpc_ncep_forecastcycle_idx ON wpc_ncep USING brin (forecastcycle);
+CREATE INDEX nhc_adeck_model_idx ON nhc_adeck USING brin (model);
+CREATE INDEX nhc_adeck_forecastcycle_idx ON nhc_adeck USING brin (forecastcycle);
 --
 --Create Brin Index on basin for nhc_fcst and nhc_btk
 --

--- a/helm/metget-server/templates/download/metget_download_workflow_adeck.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_adeck.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.config.meteorology.adeck }}
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: {{ .Release.Name }}-download-adeck
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: "Forbid"
+  startingDeadlineSeconds: 0
+  activeDeadlineSeconds: 3600
+  workflowSpec:
+    entrypoint: runner
+    serviceAccountName: operate-workflow-sa
+    ttlStrategy:
+      secondsAfterCompletion: 120    # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+      secondsAfterSuccess: 120       # Time to live after workflow is successful
+      secondsAfterFailure: 86400     # Time to live after workflow fails
+    arguments:
+      parameters:
+        - name: input-service
+          value: adeck
+    templates:
+      - name: runner
+        steps:
+        - - name: download
+            templateRef:
+              name: download-template
+              template: download-runner
+            arguments:
+              parameters:
+                - name: service
+                  value: '{{ "{{" }}workflow.parameters.input-service{{ "}}" }}'
+{{ end }}

--- a/helm/metget-server/templates/download/metget_download_workflow_adeck.yaml
+++ b/helm/metget-server/templates/download/metget_download_workflow_adeck.yaml
@@ -4,7 +4,7 @@ kind: CronWorkflow
 metadata:
   name: {{ .Release.Name }}-download-adeck
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "*/30 * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
   activeDeadlineSeconds: 3600

--- a/helm/metget-server/values.example.yaml
+++ b/helm/metget-server/values.example.yaml
@@ -122,6 +122,7 @@ config:
     nam: False
     nhc: False
     wpc: False
+    adeck: False
   #####################################################
   # Ensure that the API enforces credit limits
   #

--- a/src/executables/api/src/metget_api/adeck.py
+++ b/src/executables/api/src/metget_api/adeck.py
@@ -1,0 +1,96 @@
+###################################################################################################
+# MIT License
+#
+# Copyright (c) 2023 The Water Institute
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Author: Zach Cobell
+# Contact: zcobell@thewaterinstitute.org
+# Organization: The Water Institute
+#
+###################################################################################################
+from datetime import datetime
+from typing import Tuple, Union
+
+
+class ADeck:
+    """
+    Class to handle the ADeck endpoint
+    """
+
+    @staticmethod
+    def get(
+        year: str, basin: str, model: str, storm: int, cycle: datetime
+    ) -> Tuple[Union[dict, str], int]:
+        """
+        Method to handle the GET request for the ADeck endpoint
+
+        Args:
+            year: The year that the storm occurs
+            basin: The basin that the storm is in
+            model: The model that the storm track is from
+            storm: The storm number
+            cycle: The cycle of the storm track (i.e. datetime)
+
+        Returns:
+            The response for the ADeck endpoint
+        """
+        from libmetget.database.database import Database
+        from libmetget.database.tables import NhcAdeck
+
+        if not year or not basin or not model or not storm or not cycle:
+            return {"message": "Missing query parameters"}, 400
+
+        if not isinstance(storm, int):
+            return {"message": "Storm must be an integer"}, 400
+
+        basin = basin.upper()
+        model = model.upper()
+        if basin not in ["AL", "EP", "CP"]:
+            return {"message": "Basin must be one of 'AL', 'EP', or 'CP'"}, 400
+
+        with Database() as db, db.session() as session:
+            query_results = (
+                session.query(NhcAdeck.geometry_data)
+                .filter(NhcAdeck.storm_year == year)
+                .filter(NhcAdeck.model == model)
+                .filter(NhcAdeck.basin == basin)
+                .filter(NhcAdeck.storm == storm)
+                .filter(NhcAdeck.forecastcycle == cycle)
+                .all()
+            )
+
+            if not query_results:
+                return {"message": "No results found"}, 404
+            elif len(query_results) > 1:
+                return {"message": "Multiple results found"}, 500
+            else:
+                track_data = query_results[0].geometry_data
+                return {
+                    "message": "Success",
+                    "query": {
+                        "year": year,
+                        "basin": basin,
+                        "model": model,
+                        "storm": storm,
+                        "cycle": cycle.strftime("%Y-%m-%d %H:%M"),
+                    },
+                    "storm_track": track_data,
+                }, 200

--- a/src/executables/api/src/metget_api/api.py
+++ b/src/executables/api/src/metget_api/api.py
@@ -200,8 +200,7 @@ class MetGetADeck(Resource):
     def get(year: str, basin: str, model: str, storm: str, cycle: str):
         from .adeck import ADeck
 
-        # authorized = AccessControl.check_authorization_token(request.headers)
-        authorized = True
+        authorized = AccessControl.check_authorization_token(request.headers)
         if authorized:
             try:
                 storm = int(storm)

--- a/src/executables/download/src/metget_download/download.py
+++ b/src/executables/download/src/metget_download/download.py
@@ -27,23 +27,22 @@
 # Organization: The Water Institute
 #
 ###################################################################################################
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def generate_default_date_range():
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
-    start = datetime.utcnow()
+    start = datetime.now(timezone.utc)
     start = datetime(start.year, start.month, start.day, 0, 0, 0) - timedelta(days=1)
     end = start + timedelta(days=2)
     return start, end
 
 
 def nam_download():
-    import logging
-
     from libmetget.download.ncepnamdownloader import NcepNamdownloader
-
-    logger = logging.getLogger(__name__)
 
     start, end = generate_default_date_range()
     nam = NcepNamdownloader(start, end)
@@ -56,11 +55,7 @@ def nam_download():
 
 
 def gfs_download():
-    import logging
-
     from libmetget.download.ncepgfsdownloader import NcepGfsdownloader
-
-    logger = logging.getLogger(__name__)
 
     start, end = generate_default_date_range()
     gfs = NcepGfsdownloader(start, end)
@@ -73,11 +68,7 @@ def gfs_download():
 
 
 def gefs_download():
-    import logging
-
     from libmetget.download.ncepgefsdownloader import NcepGefsdownloader
-
-    logger = logging.getLogger(__name__)
 
     start, end = generate_default_date_range()
     gefs = NcepGefsdownloader(start, end)
@@ -90,11 +81,7 @@ def gefs_download():
 
 
 def hwrf_download():
-    import logging
-
     from libmetget.download.hwrfdownloader import HwrfDownloader
-
-    logger = logging.getLogger(__name__)
 
     start, end = generate_default_date_range()
     hwrf = HwrfDownloader(start, end)
@@ -107,12 +94,8 @@ def hwrf_download():
 
 
 def hafs_download():
-    import logging
-
     from libmetget.download.hafsdownloader import HafsDownloader
     from libmetget.sources.metfiletype import NCEP_HAFS_A, NCEP_HAFS_B
-
-    logger = logging.getLogger(__name__)
 
     start, end = generate_default_date_range()
     hafs_a = HafsDownloader(start, end, NCEP_HAFS_A)
@@ -137,11 +120,7 @@ def hafs_download():
 
 
 def nhc_download():
-    import logging
-
     from libmetget.download.nhcdownloader import NhcDownloader
-
-    logger = logging.getLogger(__name__)
 
     nhc = NhcDownloader()
     logger.info("Beginning downloading NHC data")
@@ -151,11 +130,7 @@ def nhc_download():
 
 
 def coamps_download():
-    import logging
-
     from libmetget.download.coampsdownloader import CoampsDownloader
-
-    logger = logging.getLogger(__name__)
 
     coamps = CoampsDownloader()
     logger.info("Beginning downloading COAMPS data")
@@ -165,11 +140,7 @@ def coamps_download():
 
 
 def ctcx_download():
-    import logging
-
     from libmetget.download.ctcxdownloader import CtcxDownloader
-
-    logger = logging.getLogger(__name__)
 
     ctcx = CtcxDownloader()
     n = ctcx.download()
@@ -178,11 +149,7 @@ def ctcx_download():
 
 
 def hrrr_download():
-    import logging
-
     from libmetget.download.ncephrrrdownloader import NcepHrrrdownloader
-
-    logger = logging.getLogger(__name__)
 
     start, end = generate_default_date_range()
     hrrr = NcepHrrrdownloader(start, end)
@@ -194,11 +161,7 @@ def hrrr_download():
 
 
 def hrrr_alaska_download():
-    import logging
-
     from libmetget.download.ncephrrralaskadownloader import NcepHrrrAlaskadownloader
-
-    logger = logging.getLogger(__name__)
 
     start, end = generate_default_date_range()
     hrrr = NcepHrrrAlaskadownloader(start, end)
@@ -209,17 +172,24 @@ def hrrr_alaska_download():
 
 
 def wpc_download():
-    import logging
-
     from libmetget.download.wpcdownloader import WpcDownloader
-
-    logger = logging.getLogger(__name__)
 
     start, end = generate_default_date_range()
     wpc = WpcDownloader(start, end)
     logger.info("Beginning downloading WPC data")
     n = wpc.download()
     logger.info(f"WPC complete. {n:d} files downloaded")
+    return n
+
+
+def adeck_download() -> int:
+    from libmetget.download.adeckdownloader import ADeckDownloader
+
+    a_deck = ADeckDownloader()
+    n = a_deck.download()
+
+    logger.info(f"A-Deck complete. {n:d} files downloaded")
+
     return n
 
 
@@ -233,7 +203,6 @@ def metget_download():
         level=logging.INFO,
         format="%(asctime)s :: %(levelname)s :: %(module)s :: %(message)s",
     )
-    logger = logging.getLogger(__name__)
 
     p = argparse.ArgumentParser(description="MetGet Download Function")
     p.add_argument(
@@ -248,28 +217,23 @@ def metget_download():
 
     logger.info(f"Running with configuration: {args.service:s}")
 
-    if args.service == "nam":
-        nam_download()
-    elif args.service == "gfs":
-        gfs_download()
-    elif args.service == "gefs":
-        gefs_download()
-    elif args.service == "hwrf":
-        hwrf_download()
-    elif args.service == "hafs":
-        hafs_download()
-    elif args.service == "nhc":
-        nhc_download()
-    elif args.service == "coamps":
-        coamps_download()
-    elif args.service == "ctcx":
-        ctcx_download()
-    elif args.service == "hrrr":
-        hrrr_download()
-    elif args.service == "hrrr-alaska":
-        hrrr_alaska_download()
-    elif args.service == "wpc":
-        wpc_download()
+    download_functions = {
+        "nam": nam_download,
+        "gfs": gfs_download,
+        "gefs": gefs_download,
+        "hwrf": hwrf_download,
+        "hafs": hafs_download,
+        "nhc": nhc_download,
+        "coamps": coamps_download,
+        "ctcx": ctcx_download,
+        "hrrr": hrrr_download,
+        "hrrr-alaska": hrrr_alaska_download,
+        "wpc": wpc_download,
+        "adeck": adeck_download,
+    }
+
+    if args.service in download_functions:
+        download_functions[args.service]()
     else:
         msg = "Invalid data source selected"
         raise RuntimeError(msg)

--- a/src/libraries/libmetget/src/libmetget/database/tables.py
+++ b/src/libraries/libmetget/src/libmetget/database/tables.py
@@ -478,3 +478,20 @@ class NhcFcstTable(TableBase):
     md5 = Column(String)
     accessed = Column(DateTime)
     geometry_data = Column(MutableDict.as_mutable(JSONB))
+
+
+class NhcAdeck(TableBase):
+    from sqlalchemy import Column, DateTime, Integer, String
+
+    __tablename__ = "nhc_adeck"
+
+    index = Column("id", Integer, primary_key=True)
+    storm_year = Column(Integer)
+    basin = Column(String)
+    storm = Column(Integer)
+    model = Column(String)
+    forecastcycle = Column(DateTime)
+    start_time = Column(DateTime)
+    end_time = Column(DateTime)
+    duration = Column(Integer)
+    geometry_data = Column(MutableDict.as_mutable(JSONB))

--- a/src/libraries/libmetget/src/libmetget/download/adeck.py
+++ b/src/libraries/libmetget/src/libmetget/download/adeck.py
@@ -174,10 +174,17 @@ class Track:
             RuntimeError: If the snapshot is not from the same basin and model.
         """
         if snapshot.basin == self.__basin and snapshot.model == self.__model:
-            self.__snapshots.append(snapshot)
+            if snapshot not in self.__snapshots:
+                self.__snapshots.append(snapshot)
         else:
             msg = "Invalid snapshot."
             raise RuntimeError(msg)
+
+    def snaps(self) -> List[DeckSnapshot]:
+        """
+        Returns the snapshots in the track.
+        """
+        return self.__snapshots
 
     def __repr__(self) -> str:
         """

--- a/src/libraries/libmetget/src/libmetget/download/adeck.py
+++ b/src/libraries/libmetget/src/libmetget/download/adeck.py
@@ -1,0 +1,393 @@
+###################################################################################################
+# MIT License
+#
+# Copyright (c) 2023 The Water Institute
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Author: Zach Cobell
+# Contact: zcobell@thewaterinstitute.org
+# Organization: The Water Institute
+#
+###################################################################################################
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import ClassVar, Dict, List
+
+KT_TO_MPH = 1.15078
+
+logger = logging.getLogger(__name__)
+
+
+class ADeckDownloaderException(Exception):
+    """
+    An exception to be raised when an error occurs during the A-Deck download.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class ADeckNames:
+    """
+    A class to download and store the names of the A-Deck models from the NHC server.
+    """
+
+    def __init__(self):
+        """
+        Constructor
+        """
+        self.__url = "https://ftp.nhc.noaa.gov/atcf/docs/nhc_techlist.dat"
+        self.__names = self.__download_names()
+
+    def __getitem__(self, key: str) -> str:
+        """
+        Returns the long name of the model given the abbreviation.
+        """
+        return self.__names[key]
+
+    def __download_names(self) -> Dict[str, str]:
+        """
+        Downloads the A-Deck names from the NHC server.
+
+        Returns:
+            A dictionary containing the abbreviation as the key
+            and the long name as the value.
+        """
+        import requests
+
+        response = requests.get(self.__url)
+        if response.status_code != 200:
+            msg = "Failed to download the A-Deck names."
+            raise ADeckDownloaderException(msg)
+        data = response.content.decode("utf-8").split("\n")
+
+        model_names = {}
+        for line in data[1:]:
+            name = line[4:8].strip()
+            long_name = line[68:].rstrip()
+            model_names[name] = long_name
+        return model_names
+
+    def names(self) -> dict:
+        """
+        Returns the names of the A-Deck models as a dictionary.
+
+        Returns:
+            A dictionary containing the abbreviation as the key
+            and the long name as the value.
+        """
+        return self.__names
+
+    def to_json(self, filename: str) -> None:
+        """
+        Writes the names of the A-Deck models to a JSON file.
+
+        Args:
+            filename: The name of the JSON file.
+        """
+        import json
+
+        with open(filename, "w") as f:
+            f.write(json.dumps(self.__names, indent=2))
+
+
+@dataclass
+class DeckSnapshot:
+    """
+    A class to represent a snapshot of a tropical cyclone from an A-Deck file.
+    """
+
+    basin: str | None = field(default=None)
+    cycle: datetime | None = field(default=None)
+    model: str | None = field(default=None)
+    forecast_hour: int | None = field(default=None)
+    forecast_time: datetime | None = field(default=None)
+    latitude: float | None = field(default=None)
+    longitude: float | None = field(default=None)
+    max_wind: int | None = field(default=None)
+    min_pressure: int | None = field(default=None)
+    radius_to_max_wind: int | None = field(default=None)
+
+
+class Track:
+    def __init__(self, basin: str, model: str, storm: int, year: int):
+        """
+        Constructor
+
+        Args:
+            basin: The basin of the storm.
+            model: The model used to forecast the storm.
+            storm: The storm number.
+            year: The year of the storm.
+        """
+        self.__basin = basin
+        self.__model = model
+        self.__storm = storm
+        self.__year = year
+        self.__snapshots: List[DeckSnapshot] = []
+
+    def __len__(self):
+        """
+        Returns the number of snapshots in the track.
+        """
+        return len(self.__snapshots)
+
+    def start(self) -> datetime:
+        """
+        Returns the start time of the track.
+        """
+        return self.__snapshots[0].cycle
+
+    def end(self) -> datetime:
+        """
+        Returns the end time of the track.
+        """
+        return self.__snapshots[-1].cycle
+
+    def add_snapshot(self, snapshot: DeckSnapshot):
+        """
+        Adds a snapshot to the track.
+
+        Args:
+            snapshot: The snapshot to add.
+
+        Raises:
+            RuntimeError: If the snapshot is not from the same basin and model.
+        """
+        if snapshot.basin == self.__basin and snapshot.model == self.__model:
+            self.__snapshots.append(snapshot)
+        else:
+            msg = "Invalid snapshot."
+            raise RuntimeError(msg)
+
+    def __repr__(self) -> str:
+        """
+        Returns a string representation of the track.
+        """
+        return (
+            f"Track(basin={self.__basin}, "
+            f"model={self.__model}, "
+            f"storm={self.__storm}, year={self.__year}, "
+            f"nsnap={len(self.__snapshots)}, "
+            f"nhours={self.__snapshots[-1].forecast_hour}, "
+            f"start={self.__snapshots[0].forecast_time}, "
+            f"end={self.__snapshots[-1].forecast_time})"
+        )
+
+    def to_geojson(self) -> dict:
+        """
+        Returns the track as a GeoJSON FeatureCollection.
+        """
+        from geojson import Feature, FeatureCollection, Point
+
+        return FeatureCollection(
+            [
+                Feature(
+                    geometry=Point((snapshot.longitude, snapshot.latitude)),
+                    properties={
+                        "forecast_hour": snapshot.forecast_hour,
+                        "time_utc": datetime.isoformat(snapshot.forecast_time),
+                        "max_wind_speed_mph": round(snapshot.max_wind * KT_TO_MPH, 2),
+                        "minimum_sea_level_pressure_mb": snapshot.min_pressure,
+                        "radius_to_max_wind_nmi": snapshot.radius_to_max_wind,
+                    },
+                )
+                for snapshot in self.__snapshots
+            ]
+        )
+
+
+class ModelDeck:
+    """
+    A class to represent a deck of tracks from a single model.
+    """
+
+    def __init__(self, model: str):
+        """
+        Constructor
+
+        Args:
+            model: The name of the model.
+        """
+        self.__model = model
+        self.__decks: Dict[datetime:Track] = {}
+
+    def add_snapshot(
+        self, cycle: datetime, snapshot: DeckSnapshot, storm: int, year: int
+    ) -> None:
+        """
+        Adds a snapshot to the deck.
+
+        Args:
+            cycle: The cycle time of the snapshot.
+            snapshot: The snapshot to add.
+            storm: The storm number.
+            year: The year of the storm.
+        """
+        if cycle not in self.__decks:
+            self.__decks[cycle] = Track(snapshot.basin, snapshot.model, storm, year)
+        self.__decks[cycle].add_snapshot(snapshot)
+
+    def add_deck(self, model_deck: Track, cycle: datetime) -> None:
+        """
+        Adds a deck to the model deck.
+
+        Args:
+            model_deck: The model deck to add.
+            cycle: The cycle time of the deck.
+        """
+        if model_deck is not None and cycle is not None and cycle not in self.__decks:
+            self.__decks[cycle] = model_deck
+        else:
+            msg = "Invalid deck."
+            raise RuntimeError(msg)
+
+    def cycles(self) -> List[datetime]:
+        """
+        Returns the cycles in the model
+
+        Returns:
+            A list of cycles in the model.
+        """
+        return list(self.__decks.keys())
+
+    def track(self, cycle: datetime) -> Track:
+        """
+        Returns the track for a given cycle.
+
+        Args:
+            cycle: The cycle time of the track.
+
+        Returns:
+            The track for the given cycle.
+        """
+        return self.__decks[cycle]
+
+    def __repr__(self) -> str:
+        """
+        Returns a string representation of the model deck.
+
+        Returns:
+            A string representation of the model deck.
+        """
+        first_cycle = next(iter(self.__decks.keys()))
+        last_cycle = list(self.__decks.keys())[-1]
+        return (
+            f"ModelDeck(model={self.__model}, "
+            f"n_cycles={len(self.__decks)}, "
+            f"first_cycle={self.__decks[first_cycle].start()}, "
+            f"last_cycle={self.__decks[last_cycle].start()})"
+        )
+
+
+class ADeckStorms:
+    """
+    A class to download A-Deck files from the NHC server.
+    """
+
+    BASE_URL: ClassVar = "https://ftp.nhc.noaa.gov/atcf/aid_public"
+
+    @staticmethod
+    def __generate_url(basin: str, year: int, storm: int) -> str:
+        """
+        Generates the URL for a given year and storm number.
+        """
+        if basin.lower() not in ["al", "ep", "cp"]:
+            msg = "Invalid basin."
+            raise ValueError(msg)
+
+        return f"{ADeckStorms.BASE_URL}/a{basin.lower()}{storm:02d}{year:4d}.dat.gz"
+
+    def download_storm(self, basin: str, year: int, storm: int) -> dict:
+        """
+        Downloads the A-Deck file for a given year and storm number.
+
+        Args:
+            basin: The basin of the storm.
+            year: The year of the storm.
+            storm: The storm number.
+
+        Returns:
+            A dictionary containing the parsed data from the A-Deck.
+        """
+        import gzip
+        from datetime import datetime, timedelta
+
+        import requests
+
+        url = self.__generate_url(basin, year, storm)
+        response = requests.get(url)
+        if response.status_code != 200:
+            msg = "Failed to download the A-Deck file."
+            raise ADeckDownloaderException(msg)
+
+        data = gzip.decompress(response.content).decode("utf-8").split("\n")
+
+        deck_dict = {}
+        for line in data:
+            split_line = line.strip().split(",")
+            if len(split_line) < 10:
+                continue
+
+            basin = split_line[0]
+            cycle = datetime.strptime(split_line[2].strip(), "%Y%m%d%H")
+            model = split_line[4].strip()
+            forecast_hour = int(split_line[5])
+            forecast_time = datetime.strptime(
+                split_line[2].strip(), "%Y%m%d%H"
+            ) + timedelta(hours=int(split_line[5]))
+
+            latitude = float(split_line[6][:-1]) / 10
+            if split_line[6][-1] == "S":
+                latitude = -latitude
+
+            longitude = float(split_line[7][:-1]) / 10
+            if split_line[7][-1] == "W":
+                longitude = -longitude
+
+            max_wind = int(split_line[8])
+            min_pressure = int(split_line[9])
+
+            if len(split_line) > 20:
+                radius_to_max_wind = int(split_line[20])
+            else:
+                radius_to_max_wind = 0.0
+
+            snapshot = DeckSnapshot(
+                basin=basin,
+                cycle=cycle,
+                model=model,
+                forecast_hour=forecast_hour,
+                forecast_time=forecast_time,
+                latitude=latitude,
+                longitude=longitude,
+                max_wind=max_wind,
+                min_pressure=min_pressure,
+                radius_to_max_wind=radius_to_max_wind,
+            )
+
+            if model not in deck_dict:
+                deck_dict[model] = ModelDeck(model)
+
+            deck_dict[model].add_snapshot(cycle, snapshot, storm, year)
+
+        return deck_dict

--- a/src/libraries/libmetget/src/libmetget/download/adeckdownloader.py
+++ b/src/libraries/libmetget/src/libmetget/download/adeckdownloader.py
@@ -1,0 +1,246 @@
+import logging
+from datetime import datetime
+from typing import ClassVar
+
+from libmetget.download.adeck import (
+    ADeckDownloaderException,
+    ADeckNames,
+    ADeckStorms,
+    Track,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ADeckDownloader:
+    """
+    Downloads A-Deck tracks from the NHC website and stores them in the database.
+    """
+
+    MODEL_NAMES: ClassVar = ADeckNames()
+    NHC_BASINS: ClassVar = ["AL", "EP", "CP"]
+    STORM_IDS: ClassVar = list(range(1, 31)) + list(range(90, 100))
+
+    def __init__(self):
+        """
+        Constructor for ADeckDownloader class
+        """
+        from libmetget.database.database import Database
+
+        self.__db = Database()
+        self.__session = self.__db.session()
+
+    def __get_tracks_currently_in_db(self) -> dict:
+        """
+        Get the tracks currently in the database. This allows
+        us to avoid a query to the database for each track we
+        are trying to add. Returns the dictionary in the form:
+
+        {
+            basin: {
+                storm: {
+                    model: [forecastcycle, forecastcycle, ...]
+                }
+            }
+        }
+
+        Returns:
+            dict: Dictionary of tracks currently in the database
+        """
+        from libmetget.database.tables import NhcAdeck
+
+        logger.info("Getting tracks currently in the database")
+
+        rows = (
+            self.__session.query(
+                NhcAdeck.storm_year,
+                NhcAdeck.basin,
+                NhcAdeck.model,
+                NhcAdeck.storm,
+                NhcAdeck.forecastcycle,
+            )
+            .filter(NhcAdeck.storm_year == datetime.now().year)
+            .all()
+        )
+
+        tracks_dict = {}
+        for row in rows:
+            if row.basin not in tracks_dict:
+                tracks_dict[row.basin] = {}
+            if row.storm not in tracks_dict[row.basin]:
+                tracks_dict[row.basin][row.storm] = {}
+            if row.model not in tracks_dict[row.basin][row.storm]:
+                tracks_dict[row.basin][row.storm][row.model] = []
+            tracks_dict[row.basin][row.storm][row.model].append(row.forecastcycle)
+
+        return tracks_dict
+
+    @staticmethod
+    def __dict_has_track(  # noqa: PLR0913
+        db_tracks: dict,
+        model: int,
+        year: int,
+        basin: str,
+        storm: int,
+        cycle: datetime,
+    ) -> bool:
+        """
+        Check if the dictionary has the track. This is a quick check to see if
+        the track is already in the database. This is used to avoid a query to
+        the database for each track we are trying to add. We consider this a quick
+        check because it is not safe from race conditions.
+
+        Returns:
+            bool: True if the track is in the dictionary, False otherwise
+        """
+        if year != datetime.now().year:
+            return False
+
+        return (
+            basin in db_tracks
+            and storm in db_tracks[basin]
+            and model in db_tracks[basin][storm]
+            and cycle in db_tracks[basin][storm][model]
+        )
+
+    def __db_has_track(  # noqa: PLR0913
+        self,
+        model: int,
+        year: int,
+        basin: str,
+        storm: int,
+        cycle: datetime,
+    ) -> bool:
+        """
+        Check if the database has the track. This is an approximately
+        safe check to see if the track is already in the database. This
+        is run second after the quick check
+
+        Args:
+            model (int): Model number
+            year (int): Year of the storm
+            basin (str): Basin of the storm
+            storm (int): Storm number
+            cycle (datetime): Cycle of the forecast
+
+        Returns:
+            bool: True if the track is in the database, False otherwise
+        """
+        from libmetget.database.tables import NhcAdeck
+
+        return (
+            self.__session.query(NhcAdeck)
+            .filter(
+                NhcAdeck.storm_year == year,
+                NhcAdeck.model == model,
+                NhcAdeck.basin == basin,
+                NhcAdeck.storm == storm,
+                NhcAdeck.forecastcycle == cycle,
+            )
+            .count()
+            > 0
+        )
+
+    def __db_add_track(  # noqa: PLR0913
+        self,
+        db_tracks: dict,
+        model: int,
+        year: int,
+        basin: str,
+        storm: int,
+        cycle: datetime,
+        track: Track,
+    ) -> bool:
+        """
+        Add the track to the database if it is not already there. The
+        method will check if the track exists in the database before
+        adding it
+
+        Args:
+            db_tracks (dict): Dictionary of tracks currently in the database
+            model (int): Model number
+            year (int): Year of the storm
+            basin (str): Basin of the storm
+            storm (int): Storm number
+            cycle (datetime): Cycle of the forecast
+            track (Track): Track object to add to the database
+
+        Returns:
+            bool: True if the track was added, False otherwise
+        """
+        import math
+
+        from libmetget.database.tables import NhcAdeck
+
+        # Check the dictionary (first - fast) and if found, then check the database
+        if not ADeckDownloader.__dict_has_track(
+            db_tracks, model, year, basin, storm, cycle
+        ) and not self.__db_has_track(model, year, basin, storm, cycle):
+            logger.info(f"Adding {basin}{storm:02d} {model} {cycle} to the database")
+            self.__session.add(
+                NhcAdeck(
+                    storm_year=year,
+                    model=model,
+                    basin=basin,
+                    storm=storm,
+                    forecastcycle=cycle,
+                    start_time=track.start(),
+                    end_time=track.end(),
+                    duration=math.floor(
+                        (track.end() - track.start()).total_seconds() / 3600.0
+                    ),
+                    geometry_data=track.to_geojson(),
+                )
+            )
+            return True
+        return False
+
+    def download(self) -> None:
+        """
+        Download the A-Deck tracks from the NHC website and store them in the database
+        """
+        current_year = datetime.now().year
+        track_count = 0
+
+        db_tracks = self.__get_tracks_currently_in_db()
+
+        for basin in ADeckDownloader.NHC_BASINS:
+            for storm in ADeckDownloader.STORM_IDS:
+                this_storm_track_count = 0
+                try:
+                    logger.info(f"Looking for {basin}{storm:02d}")
+                    deck = ADeckStorms().download_storm(basin, current_year, storm)
+
+                    logger.info(
+                        f"Checking database for {basin}{storm:02d} available cycles"
+                    )
+                    for model in deck:
+                        for cycle in deck[model].cycles():
+                            track = deck[model].track(cycle)
+                            added = self.__db_add_track(
+                                db_tracks,
+                                model,
+                                current_year,
+                                basin,
+                                storm,
+                                cycle,
+                                track,
+                            )
+                            if added:
+                                track_count += 1
+                                this_storm_track_count += 1
+                except ADeckDownloaderException:
+                    continue
+
+                if this_storm_track_count > 0:
+                    self.__session.commit()
+
+        logger.info(f"Added {track_count} tracks to the database")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    ADeckDownloader().download()

--- a/src/libraries/libmetget/src/libmetget/download/adeckdownloader.py
+++ b/src/libraries/libmetget/src/libmetget/download/adeckdownloader.py
@@ -195,7 +195,7 @@ class ADeckDownloader:
             return True
         return False
 
-    def download(self) -> None:
+    def download(self) -> int:
         """
         Download the A-Deck tracks from the NHC website and store them in the database
         """
@@ -235,12 +235,4 @@ class ADeckDownloader:
                 if this_storm_track_count > 0:
                     self.__session.commit()
 
-        logger.info(f"Added {track_count} tracks to the database")
-
-
-if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    ADeckDownloader().download()
+        return track_count


### PR DESCRIPTION
Adding a downloader and an endpoint for NHC ADeck data

The data can be queried from the server using the following URL parameters:

```
https://api.hostname.org/adeck/<year>/<basin>/<model>/<storm>/<cycle>
```

where:
* `year` = 4 digit year
* `basin` = two character basin code (i.e. AL, EP, CP)
* `model` = four character model code (i.e. GFS = AVNO). Full list of model 4 character codes can be found here: https://ftp.nhc.noaa.gov/atcf/docs/nhc_techlist.dat
* `cycle` = Date string(i.e. `2024-10-09T00:00`)