### PR TITLE
Allow user to specify 'all' for either storm or model ADeck parameters

### DIFF
--- a/src/executables/api/src/metget_api/adeck.py
+++ b/src/executables/api/src/metget_api/adeck.py
@@ -36,11 +36,105 @@ class ADeck:
     """
 
     @staticmethod
+    def __standardize_response(message: str, status_code: int) -> dict:
+        """
+        Method to standardize the response for the ADeck endpoint
+
+        Args:
+            message: The message to include in the response
+            status_code: The status code to include in the response
+
+        Returns:
+            The standardized response for the ADeck endpoint
+        """
+        return {"statusCode": status_code, "body": {"message": message}}
+
+    @staticmethod
     def get(
-        year: str, basin: str, model: str, storm: int, cycle: datetime
+        year: str, basin: str, model: str, storm: int | str, cycle: datetime
     ) -> Tuple[Union[dict, str], int]:
         """
         Method to handle the GET request for the ADeck endpoint
+
+        Args:
+            year: The year that the storm occurs
+            basin: The basin that the storm is in
+            model: The model that the storm track is from
+            storm: The storm number or 'all' for all active storms at the given cycle
+            cycle: The cycle of the storm track (i.e. datetime)
+
+        Returns:
+            The response for the ADeck endpoint
+        """
+        basin = basin.upper()
+        model = model.upper()
+        if basin not in ["AL", "EP", "CP"]:
+            return (
+                ADeck.__standardize_response("Basin must be 'AL', 'EP', or 'CP'", 400),
+                400,
+            )
+
+        if isinstance(storm, str) and storm.lower() == "all":
+            return ADeck.__get_all_storms(year, basin, model, cycle)
+        elif isinstance(storm, int) and model.lower() == "all":
+            return ADeck.__get_one_storm_all_models(year, basin, storm, cycle)
+        elif isinstance(storm, int) and model.lower() != "all":
+            return ADeck.__get_one_storm_one_model(year, basin, model, storm, cycle)
+        else:
+            return ADeck.__standardize_response("Invalid request", 400), 400
+
+    @staticmethod
+    def __get_one_storm_all_models(
+        year: str, basin: str, storm: int, cycle: datetime
+    ) -> Tuple[Union[dict, str], int]:
+        """
+        Method to get the storm track for a single storm for all models
+
+        Args:
+            year: The year that the storm occurs
+            basin: The basin that the storm is in
+            storm: The storm number
+            cycle: The cycle of the storm track (i.e. datetime)
+
+        Returns:
+            The response for the ADeck endpoint
+        """
+        from libmetget.database.database import Database
+        from libmetget.database.tables import NhcAdeck
+
+        with Database() as db, db.session() as session:
+            query_results = (
+                session.query(NhcAdeck.model, NhcAdeck.geometry_data)
+                .filter(NhcAdeck.storm_year == year)
+                .filter(NhcAdeck.basin == basin)
+                .filter(NhcAdeck.storm == storm)
+                .filter(NhcAdeck.forecastcycle == cycle)
+                .all()
+            )
+
+            if not query_results:
+                return ADeck.__standardize_response("No results found", 404), 404
+            else:
+                storm_data = {}
+                for model, track in query_results:
+                    storm_data[model] = track
+                return {
+                    "message": "Success",
+                    "query": {
+                        "year": year,
+                        "basin": basin,
+                        "storm": storm,
+                        "cycle": cycle.strftime("%Y-%m-%d %H:%M"),
+                    },
+                    "storm_tracks": storm_data,
+                }, 200
+
+    @staticmethod
+    def __get_one_storm_one_model(
+        year: str, basin: str, model: str, storm: int, cycle: datetime
+    ) -> Tuple[Union[dict, str], int]:
+        """
+        Method to get the storm track for a single storm
 
         Args:
             year: The year that the storm occurs
@@ -55,17 +149,6 @@ class ADeck:
         from libmetget.database.database import Database
         from libmetget.database.tables import NhcAdeck
 
-        if not year or not basin or not model or not storm or not cycle:
-            return {"message": "Missing query parameters"}, 400
-
-        if not isinstance(storm, int):
-            return {"message": "Storm must be an integer"}, 400
-
-        basin = basin.upper()
-        model = model.upper()
-        if basin not in ["AL", "EP", "CP"]:
-            return {"message": "Basin must be one of 'AL', 'EP', or 'CP'"}, 400
-
         with Database() as db, db.session() as session:
             query_results = (
                 session.query(NhcAdeck.geometry_data)
@@ -78,9 +161,9 @@ class ADeck:
             )
 
             if not query_results:
-                return {"message": "No results found"}, 404
+                return ADeck.__standardize_response("No results found", 404), 404
             elif len(query_results) > 1:
-                return {"message": "Multiple results found"}, 500
+                return ADeck.__standardize_response("Multiple results found", 500), 500
             else:
                 track_data = query_results[0].geometry_data
                 return {
@@ -93,4 +176,50 @@ class ADeck:
                         "cycle": cycle.strftime("%Y-%m-%d %H:%M"),
                     },
                     "storm_track": track_data,
+                }, 200
+
+    @staticmethod
+    def __get_all_storms(
+        year: str, basin: str, model: str, cycle: datetime
+    ) -> Tuple[Union[dict, str], int]:
+        """
+        Method to get all active storms at a given cycle for a model
+
+        Args:
+            year: The year that the storm occurs
+            basin: The basin that the storm is in
+            model: The model that the storm track is from
+            cycle: The cycle of the storm track (i.e. datetime)
+
+        Returns:
+            The response for the ADeck endpoint
+        """
+        from libmetget.database.database import Database
+        from libmetget.database.tables import NhcAdeck
+
+        with Database() as db, db.session() as session:
+            query_results = (
+                session.query(NhcAdeck.storm, NhcAdeck.geometry_data)
+                .filter(NhcAdeck.storm_year == year)
+                .filter(NhcAdeck.model == model)
+                .filter(NhcAdeck.basin == basin)
+                .filter(NhcAdeck.forecastcycle == cycle)
+                .all()
+            )
+
+            if not query_results:
+                return ADeck.__standardize_response("No results found", 404), 404
+            else:
+                storm_data = {}
+                for storm, track in query_results:
+                    storm_data[storm] = track
+                return {
+                    "message": "Success",
+                    "query": {
+                        "year": year,
+                        "basin": basin,
+                        "model": model,
+                        "cycle": cycle.strftime("%Y-%m-%d %H:%M"),
+                    },
+                    "storm_tracks": storm_data,
                 }, 200

--- a/src/executables/api/src/metget_api/api.py
+++ b/src/executables/api/src/metget_api/api.py
@@ -198,21 +198,43 @@ class MetGetADeck(Resource):
 
     @staticmethod
     def get(year: str, basin: str, model: str, storm: str, cycle: str):
+        """
+        Method to handle the GET request for the ADeck endpoint
+
+        Args:
+            year: The year that the storm occurs
+            basin: The basin that the storm is in
+            model: The model that the storm track is from
+            storm: The storm number or 'all' for all active storms at the given cycle
+            cycle: The cycle of the storm track (i.e. datetime)
+
+        Returns:
+            The response for the ADeck endpoint
+        """
         from .adeck import ADeck
 
         authorized = AccessControl.check_authorization_token(request.headers)
         if authorized:
             try:
-                storm = int(storm)
-                if storm < 0 or storm > 99:
-                    raise ValueError
+                if isinstance(storm, str) and storm.lower() == "all":
+                    storm = "all"
+                else:
+                    storm = int(storm)
+                    if storm < 0 or storm > 99:
+                        raise ValueError
             except ValueError:
-                return {"message": "Invalid storm number"}, 400
+                return {
+                    "statusCode": 400,
+                    "body": {"message": "Invalid storm number"},
+                }, 400
 
             try:
                 cycle = datetime.fromisoformat(cycle)
             except ValueError:
-                return {"message": "Invalid cycle provided"}, 400
+                return {
+                    "statusCode": 400,
+                    "body": {"message": "Invalid cycle format"},
+                }, 400
 
             message, status_code = ADeck.get(year, basin, model, storm, cycle)
         else:


### PR DESCRIPTION
This allows the user to query the entire ensemble in a single query or query all active storms in a single query