### PR TITLE
Adding whitelisted sources for adeck requests

### DIFF
--- a/src/executables/api/src/metget_api/api.py
+++ b/src/executables/api/src/metget_api/api.py
@@ -213,7 +213,9 @@ class MetGetADeck(Resource):
         """
         from .adeck import ADeck
 
-        authorized = AccessControl.check_authorization_token(request.headers)
+        authorized = AccessControl.check_authorization_token(
+            request.headers, with_whitelist=True
+        )
         if authorized:
             try:
                 if isinstance(storm, str) and storm.lower() == "all":


### PR DESCRIPTION
This allows particular websites to bypass the api-key check for the ADeck API. This isn't a huge hurdle for scripting, but prevents websites we don't want accessing the data without discussion.