### PR TITLE
Locking python version to 3.12

### DIFF
--- a/containers/api/Dockerfile
+++ b/containers/api/Dockerfile
@@ -1,10 +1,11 @@
 FROM condaforge/miniforge3 AS conda
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=3.12
 
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 
-RUN conda create -y -p /env python=3 boto3 bs4 certifi cfgrib feedparser geojson \
+RUN conda create -y -p /env python=${PYTHON_VERSION} boto3 bs4 certifi cfgrib feedparser geojson \
                                      geopandas h5py netCDF4 numba numpy psycopg2 \
                                      python-dateutil requests schema scipy shapely sqlalchemy \
                                      xarray flask flask-limiter flask-restful \

--- a/containers/build/Dockerfile
+++ b/containers/build/Dockerfile
@@ -1,6 +1,7 @@
 FROM condaforge/miniforge3:latest AS conda
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=3.12
 ARG TARGETARCH
 ARG TARGETPLATFORM
 
@@ -8,7 +9,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 
-RUN conda create -y -p /env python=3 boto3 bs4 certifi cfgrib feedparser geojson \
+RUN conda create -y -p /env python=${PYTHON_VERSION} boto3 bs4 certifi cfgrib feedparser geojson \
                                      geopandas h5py netCDF4 numba numpy psycopg2 \
                                      python-dateutil requests schema scipy shapely sqlalchemy \
                                      xarray eccodes

--- a/containers/download/Dockerfile
+++ b/containers/download/Dockerfile
@@ -1,10 +1,11 @@
 FROM condaforge/miniforge3 AS conda
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=3.12
 
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 
-RUN conda create -y -p /env python=3 boto3 bs4 certifi cfgrib feedparser geojson \
+RUN conda create -y -p /env python=${PYTHON_VERSION} boto3 bs4 certifi cfgrib feedparser geojson \
                                      geopandas h5py netCDF4 numba numpy psycopg2 \
                                      python-dateutil requests schema scipy shapely sqlalchemy \
                                      xarray

--- a/containers/utilities/Dockerfile
+++ b/containers/utilities/Dockerfile
@@ -1,10 +1,11 @@
 FROM condaforge/miniforge3 AS conda
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=3.12
 
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 
-RUN conda create -y -p /env python=3 boto3 bs4 certifi cfgrib feedparser geojson \
+RUN conda create -y -p /env python=${PYTHON_VERSION} boto3 bs4 certifi cfgrib feedparser geojson \
                                      geopandas h5py netCDF4 numba numpy psycopg2 \
                                      python-dateutil requests schema scipy shapely sqlalchemy \
                                      xarray


### PR DESCRIPTION
The triangle package needs to be updated to a newer version which is available on their github. The seems due to changes in python 3.12 --> python 3.13 for the cython api