### PR TITLE
Allow argo-workflow to create `workflowtaskresults`

### DIFF
--- a/helm/metget-server/templates/argo/operate-workflow-sa.yaml
+++ b/helm/metget-server/templates/argo/operate-workflow-sa.yaml
@@ -18,6 +18,7 @@ rules:
       - workflowtemplates
       - cronworkflows
       - clusterworkflowtemplates
+      - workflowtaskresults
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
When I deployed metget-server to my Kubernetes v1.32 cluster using the bundled Helm chart, the periodic job to download data would fail with the following error:

```
Error (exit code 64): workflowtaskresults.argoproj.io is forbidden: User
"system:serviceaccount:metget-sre:operate-workflow-sa" cannot create
resource "workflowtaskresults" in API group "argoproj.io" in the
namespace "metget-sre"
```

After making the change, it has been running successfully as seen in this screenshot:

![Screenshot 2025-03-31 at 2 26 55 PM](https://github.com/user-attachments/assets/7e124410-0b3b-4738-a061-a7b6a17c53c2)