### PR TITLE
Skipping zero hour in COAMPS-TC precip

### DIFF
--- a/helm/metget-server/Chart.yaml
+++ b/helm/metget-server/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: metget-server
 description: A deployment of the metget-server instance
 type: application
-version: 0.3.1
-appVersion: "0.3.1"
+version: 0.4.1
+appVersion: "0.4.1"
 icon: https://raw.githubusercontent.com/waterinstitute/metget-server/main/img/MetGet_logo_square.png

--- a/src/libraries/libmetget/src/libmetget/sources/metfiletype.py
+++ b/src/libraries/libmetget/src/libmetget/sources/metfiletype.py
@@ -528,7 +528,8 @@ COAMPS_TC = MetFileAttributes(
             "long_name": "Hourly precipitation",
             "var_name": "precip",
             "scale": 3600.0,
-            "is_accumulated": True,
+            "is_accumulated": False,
+            "skip_0": True,
         },
         MetDataType.HUMIDITY: {
             "type": MetDataType.HUMIDITY,


### PR DESCRIPTION
Had been reported as an accumulated, however, it's just that the zero hour is empty not that the variable is accumulated