### PR TITLE
Updating code to better handle timout errors from NOAA servers

### DIFF
--- a/src/libraries/libmetget/src/libmetget/download/noaadownloader.py
+++ b/src/libraries/libmetget/src/libmetget/download/noaadownloader.py
@@ -475,10 +475,11 @@ class NoaaDownloader:
                 http.mount("http://", adaptor)
 
                 inv = http.get(info["inv"], timeout=30)
-                inv.raise_for_status()
-                if inv.status_code in (302, 403):
+                if inv.status_code in (302, 403, 404):
                     logger.error("RESP: ".format())
                     return None, 0, 0
+                else:
+                    inv.raise_for_status()
 
                 inv_lines = str(inv.text).split("\n")
                 retlist = []


### PR DESCRIPTION
# Timeout Errors
The timeout errors in the WPC downloader (FTP) were due to the Python FTP library using Python's global connection timeout. The issue with that is the global value is set to (the equivalent of) `None` within the python C source code. This sets a value for the timeout and also gracefully handles timeout errors for the NHC FTP, WPC, and HWRF modules. 