### PR TITLE
Fixing ADeck initialization

### DIFF
--- a/src/libraries/libmetget/src/libmetget/download/adeckdownloader.py
+++ b/src/libraries/libmetget/src/libmetget/download/adeckdownloader.py
@@ -19,9 +19,15 @@ class ADeckDownloader:
     Downloads A-Deck tracks from the NHC website and stores them in the database.
     """
 
-    MODEL_NAMES: ClassVar = ADeckNames()
+    MODEL_NAMES: ClassVar = None
     NHC_BASINS: ClassVar = ["AL", "EP", "CP"]
     STORM_IDS: ClassVar = list(range(1, 31)) + list(range(90, 100))
+
+    @classmethod
+    def get_model_names(cls) -> ADeckNames:
+        if cls.MODEL_NAMES is None:
+            cls.MODEL_NAMES = ADeckNames()
+        return cls.MODEL_NAMES
 
     def __init__(self) -> None:
         """


### PR DESCRIPTION
The ADeck downloader reached out to the NOAA ftp even when it wasn't being used, just if it was imported. This caused errors with the NOAA ftp to propagate to other meteorological data types. We've changed the initialization to be lazy so it no longer exhibits this behavior