### PR TITLE
Add ALL basin support to adeck endpoint

### DIFF
--- a/src/executables/api/src/metget_api/adeck.py
+++ b/src/executables/api/src/metget_api/adeck.py
@@ -27,7 +27,7 @@
 #
 ###################################################################################################
 from datetime import datetime
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 from libmetget.database.database import Database
 from libmetget.database.tables import NhcAdeck
@@ -58,27 +58,35 @@ class ADeck:
         """
         basin = basin.upper()
         model = model.upper()
-        if basin not in ["AL", "EP", "CP"]:
-            return {"message": "Basin must be 'AL', 'EP', or 'CP'"}, 400
+        if basin == "ALL":
+            # A value of None signals the helper methods to return data for
+            # every basin (no basin filter is applied to the query).
+            query_basin = None
+        elif basin in ["AL", "EP", "CP"]:
+            query_basin = basin
+        else:
+            return {"message": "Basin must be 'AL', 'EP', 'CP', or 'ALL'"}, 400
 
         if isinstance(storm, str) and storm.lower() == "all":
-            return ADeck.__get_all_storms(year, basin, model, cycle)
+            return ADeck.__get_all_storms(year, query_basin, model, cycle)
         if isinstance(storm, int) and model.lower() == "all":
-            return ADeck.__get_one_storm_all_models(year, basin, storm, cycle)
+            return ADeck.__get_one_storm_all_models(year, query_basin, storm, cycle)
         if isinstance(storm, int) and model.lower() != "all":
-            return ADeck.__get_one_storm_one_model(year, basin, model, storm, cycle)
+            return ADeck.__get_one_storm_one_model(
+                year, query_basin, model, storm, cycle
+            )
         return {"message": "Invalid request"}, 400
 
     @staticmethod
     def __get_one_storm_all_models(
-        year: str, basin: str, storm: int, cycle: datetime
+        year: str, basin: Optional[str], storm: int, cycle: datetime
     ) -> Tuple[Union[dict, str], int]:
         """
         Method to get the storm track for a single storm for all models.
 
         Args:
             year: The year that the storm occurs
-            basin: The basin that the storm is in
+            basin: The basin that the storm is in, or None for all basins
             storm: The storm number
             cycle: The cycle of the storm track (i.e. datetime)
 
@@ -87,25 +95,30 @@ class ADeck:
 
         """
         with Database() as db, db.session() as session:
-            query_results = (
-                session.query(NhcAdeck.model, NhcAdeck.geometry_data)
+            query = (
+                session.query(NhcAdeck.basin, NhcAdeck.model, NhcAdeck.geometry_data)
                 .filter(NhcAdeck.storm_year == year)
-                .filter(NhcAdeck.basin == basin)
                 .filter(NhcAdeck.storm == storm)
                 .filter(NhcAdeck.forecastcycle == cycle)
-                .all()
             )
+            if basin is not None:
+                query = query.filter(NhcAdeck.basin == basin)
+            query_results = query.all()
 
             if not query_results:
                 return {"message": "No results found"}, 404
-            storm_data = {}
-            for model, track in query_results:
-                storm_data[model] = track
+            if basin is None:
+                # Nest tracks by basin to avoid collisions between basins
+                storm_data = {}
+                for result_basin, model, track in query_results:
+                    storm_data.setdefault(result_basin, {})[model] = track
+            else:
+                storm_data = {model: track for _, model, track in query_results}
             return {
                 "message": "Success",
                 "query": {
                     "year": year,
-                    "basin": basin,
+                    "basin": basin if basin is not None else "ALL",
                     "storm": storm,
                     "cycle": cycle.strftime("%Y-%m-%d %H:%M"),
                 },
@@ -114,14 +127,14 @@ class ADeck:
 
     @staticmethod
     def __get_one_storm_one_model(
-        year: str, basin: str, model: str, storm: int, cycle: datetime
+        year: str, basin: Optional[str], model: str, storm: int, cycle: datetime
     ) -> Tuple[Union[dict, str], int]:
         """
         Method to get the storm track for a single storm.
 
         Args:
             year: The year that the storm occurs
-            basin: The basin that the storm is in
+            basin: The basin that the storm is in, or None for all basins
             model: The model that the storm track is from
             storm: The storm number
             cycle: The cycle of the storm track (i.e. datetime)
@@ -131,18 +144,36 @@ class ADeck:
 
         """
         with Database() as db, db.session() as session:
-            query_results = (
-                session.query(NhcAdeck.geometry_data)
+            query = (
+                session.query(NhcAdeck.basin, NhcAdeck.geometry_data)
                 .filter(NhcAdeck.storm_year == year)
                 .filter(NhcAdeck.model == model)
-                .filter(NhcAdeck.basin == basin)
                 .filter(NhcAdeck.storm == storm)
                 .filter(NhcAdeck.forecastcycle == cycle)
-                .all()
             )
+            if basin is not None:
+                query = query.filter(NhcAdeck.basin == basin)
+            query_results = query.all()
 
             if not query_results:
                 return {"message": "No results found"}, 404
+
+            if basin is None:
+                # Return one track per basin (a storm number may exist in
+                # multiple basins, e.g. AL05 and EP05)
+                storm_data = dict(query_results)
+                return {
+                    "message": "Success",
+                    "query": {
+                        "year": year,
+                        "basin": "ALL",
+                        "model": model,
+                        "storm": storm,
+                        "cycle": cycle.strftime("%Y-%m-%d %H:%M"),
+                    },
+                    "storm_tracks": storm_data,
+                }, 200
+
             if len(query_results) > 1:
                 return {"message": "Multiple results found"}, 500
             track_data = query_results[0].geometry_data
@@ -160,14 +191,14 @@ class ADeck:
 
     @staticmethod
     def __get_all_storms(
-        year: str, basin: str, model: str, cycle: datetime
+        year: str, basin: Optional[str], model: str, cycle: datetime
     ) -> Tuple[Union[dict, str], int]:
         """
         Method to get all active storms at a given cycle for a model.
 
         Args:
             year: The year that the storm occurs
-            basin: The basin that the storm is in
+            basin: The basin that the storm is in, or None for all basins
             model: The model that the storm track is from
             cycle: The cycle of the storm track (i.e. datetime)
 
@@ -176,25 +207,30 @@ class ADeck:
 
         """
         with Database() as db, db.session() as session:
-            query_results = (
-                session.query(NhcAdeck.storm, NhcAdeck.geometry_data)
+            query = (
+                session.query(NhcAdeck.basin, NhcAdeck.storm, NhcAdeck.geometry_data)
                 .filter(NhcAdeck.storm_year == year)
                 .filter(NhcAdeck.model == model)
-                .filter(NhcAdeck.basin == basin)
                 .filter(NhcAdeck.forecastcycle == cycle)
-                .all()
             )
+            if basin is not None:
+                query = query.filter(NhcAdeck.basin == basin)
+            query_results = query.all()
 
             if not query_results:
                 return {"message": "No results found"}, 404
-            storm_data = {}
-            for storm, track in query_results:
-                storm_data[storm] = track
+            if basin is None:
+                # Nest storms by basin to avoid collisions between basins
+                storm_data = {}
+                for result_basin, storm, track in query_results:
+                    storm_data.setdefault(result_basin, {})[storm] = track
+            else:
+                storm_data = {storm: track for _, storm, track in query_results}
             return {
                 "message": "Success",
                 "query": {
                     "year": year,
-                    "basin": basin,
+                    "basin": basin if basin is not None else "ALL",
                     "model": model,
                     "cycle": cycle.strftime("%Y-%m-%d %H:%M"),
                 },

--- a/src/executables/api/tests/conftest.py
+++ b/src/executables/api/tests/conftest.py
@@ -1,0 +1,12 @@
+###################################################################################################
+# Pytest configuration for the metget_api tests.
+#
+# Importing libmetget.database.tables (a transitive import of metget_api.adeck)
+# reads a couple of table names from the environment at import time. Set dummy
+# values here, before any test module is collected, so the import succeeds
+# without a live database.
+###################################################################################################
+import os
+
+os.environ.setdefault("METGET_API_KEY_TABLE", "apikey")
+os.environ.setdefault("METGET_REQUEST_TABLE", "request")

--- a/src/executables/api/tests/test_adeck.py
+++ b/src/executables/api/tests/test_adeck.py
@@ -1,0 +1,192 @@
+###################################################################################################
+# Tests for the ADeck endpoint, focused on the "ALL" basin behavior.
+#
+# When the basin is requested as "ALL", the endpoint must:
+#   * pass validation (the legacy code only accepted AL/EP/CP),
+#   * NOT apply a basin filter to the query, and
+#   * nest the returned tracks by basin so storm numbers that exist in more than
+#     one basin (e.g. AL09 and EP09) do not collide.
+#
+# A specific basin must keep its original (flat) response shape and continue to
+# filter the query by basin.
+#
+# The database is mocked: a fake Database/session records the filter criteria
+# applied to the query and returns a predetermined set of rows, so the tests
+# exercise the request-shaping logic without a live database.
+###################################################################################################
+from collections.abc import Callable
+from datetime import datetime
+
+import metget_api.adeck as adeck_module
+import pytest
+from metget_api.adeck import ADeck
+
+CYCLE = datetime(2024, 9, 1, 0, 0)
+
+# Fixture that, given the rows the fake query should return, patches the
+# database and returns the list recording the filter criteria applied.
+PatchDb = Callable[[list], list]
+
+
+class _FakeQuery:
+    """Chainable stand-in for a SQLAlchemy query that records its filters."""
+
+    def __init__(self, rows: list, recorded_filters: list) -> None:
+        self._rows = rows
+        self._recorded_filters = recorded_filters
+
+    def filter(self, *criteria: object) -> "_FakeQuery":
+        self._recorded_filters.extend(criteria)
+        return self
+
+    def all(self) -> list:
+        return self._rows
+
+
+class _FakeSession:
+    def __init__(self, rows: list, recorded_filters: list) -> None:
+        self._rows = rows
+        self._recorded_filters = recorded_filters
+
+    def __enter__(self) -> "_FakeSession":
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+    def query(self, *_entities: object) -> _FakeQuery:
+        return _FakeQuery(self._rows, self._recorded_filters)
+
+
+class _FakeDatabase:
+    def __init__(self, rows: list, recorded_filters: list) -> None:
+        self._rows = rows
+        self._recorded_filters = recorded_filters
+
+    def __enter__(self) -> "_FakeDatabase":
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+    def session(self) -> _FakeSession:
+        return _FakeSession(self._rows, self._recorded_filters)
+
+
+@pytest.fixture
+def patch_db(monkeypatch: pytest.MonkeyPatch) -> PatchDb:
+    """
+    Patch ADeck's Database with a fake that returns ``rows``.
+
+    Returns the list that records the filter criteria applied to the query so
+    tests can assert whether a basin filter was used.
+    """
+
+    def _patch(rows: list) -> list:
+        recorded_filters: list = []
+        monkeypatch.setattr(
+            adeck_module,
+            "Database",
+            lambda: _FakeDatabase(rows, recorded_filters),
+        )
+        return recorded_filters
+
+    return _patch
+
+
+def _basin_filter_applied(recorded_filters: list) -> bool:
+    """True if any recorded filter constrains the basin column."""
+    return any(
+        getattr(getattr(f, "left", None), "name", None) == "basin"
+        for f in recorded_filters
+    )
+
+
+def test_get_rejects_invalid_basin(patch_db: PatchDb) -> None:
+    patch_db([])
+    message, status = ADeck.get("2024", "XX", "OFCL", "all", CYCLE)
+    assert isinstance(message, dict)
+    assert status == 400
+    assert "AL" in message["message"]
+    assert "ALL" in message["message"]
+
+
+def test_all_basins_all_storms_nested_by_basin(patch_db: PatchDb) -> None:
+    # storm="all", model="OFCL", basin="all" -> nest {basin: {storm: track}}.
+    # Storm number 9 exists in both AL and EP and must not collide.
+    rows = [
+        ("AL", 9, {"track": "al09"}),
+        ("AL", 12, {"track": "al12"}),
+        ("EP", 9, {"track": "ep09"}),
+    ]
+    recorded = patch_db(rows)
+
+    message, status = ADeck.get("2024", "all", "OFCL", "all", CYCLE)
+    assert isinstance(message, dict)
+
+    assert status == 200
+    assert message["query"]["basin"] == "ALL"
+    assert message["storm_tracks"] == {
+        "AL": {9: {"track": "al09"}, 12: {"track": "al12"}},
+        "EP": {9: {"track": "ep09"}},
+    }
+    # The defining behavior: no basin filter is applied for ALL.
+    assert not _basin_filter_applied(recorded)
+
+
+def test_all_basins_one_storm_all_models(patch_db: PatchDb) -> None:
+    # storm=9, model="all", basin="all" -> nest {basin: {model: track}}.
+    rows = [
+        ("AL", "OFCL", {"track": "al-ofcl"}),
+        ("AL", "HWRF", {"track": "al-hwrf"}),
+        ("EP", "OFCL", {"track": "ep-ofcl"}),
+    ]
+    recorded = patch_db(rows)
+
+    message, status = ADeck.get("2024", "all", "all", 9, CYCLE)
+    assert isinstance(message, dict)
+
+    assert status == 200
+    assert message["query"]["basin"] == "ALL"
+    assert message["storm_tracks"] == {
+        "AL": {"OFCL": {"track": "al-ofcl"}, "HWRF": {"track": "al-hwrf"}},
+        "EP": {"OFCL": {"track": "ep-ofcl"}},
+    }
+    assert not _basin_filter_applied(recorded)
+
+
+def test_all_basins_one_storm_one_model(patch_db: PatchDb) -> None:
+    # storm=9, model="OFCL", basin="all" -> one track per basin keyed by basin.
+    rows = [
+        ("AL", {"track": "al09"}),
+        ("EP", {"track": "ep09"}),
+    ]
+    recorded = patch_db(rows)
+
+    message, status = ADeck.get("2024", "all", "OFCL", 9, CYCLE)
+    assert isinstance(message, dict)
+
+    assert status == 200
+    assert message["query"]["basin"] == "ALL"
+    assert message["storm_tracks"] == {
+        "AL": {"track": "al09"},
+        "EP": {"track": "ep09"},
+    }
+    assert not _basin_filter_applied(recorded)
+
+
+def test_specific_basin_keeps_flat_shape_and_filters(patch_db: PatchDb) -> None:
+    # A specific basin must still filter by basin and use the legacy flat shape.
+    rows = [
+        ("AL", 9, {"track": "al09"}),
+        ("AL", 12, {"track": "al12"}),
+    ]
+    recorded = patch_db(rows)
+
+    message, status = ADeck.get("2024", "al", "OFCL", "all", CYCLE)
+    assert isinstance(message, dict)
+
+    assert status == 200
+    assert message["query"]["basin"] == "AL"
+    assert message["storm_tracks"] == {9: {"track": "al09"}, 12: {"track": "al12"}}
+    assert _basin_filter_applied(recorded)


### PR DESCRIPTION
The adeck endpoint previously rejected any basin other than AL, EP, or CP. Accept "ALL" (case-insensitive) to return data across every basin.

When ALL is requested, the basin filter is skipped and results are nested by basin in the response so storm numbers shared across basins (e.g. AL09 and EP09) do not collide. Specific-basin requests keep their original flat response shape.