### PR TITLE
Fix adeck downloader crashing on connection timeouts

### DIFF
--- a/src/libraries/libmetget/src/libmetget/download/adeck.py
+++ b/src/libraries/libmetget/src/libmetget/download/adeck.py
@@ -90,7 +90,7 @@ class ADeckNames:
             and the long name as the value.
 
         """
-        response = requests.get(self.__url)
+        response = requests.get(self.__url, timeout=30)
         if response.status_code != 200:
             msg = "Failed to download the A-Deck names."
             raise ADeckDownloaderException(msg)
@@ -389,7 +389,7 @@ class ADeckStorms:
 
         """
         url, is_gzipped = self.__generate_url(basin, year, storm)
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         if response.status_code != 200:
             msg = "Failed to download the A-Deck file."
             raise ADeckDownloaderException(msg)

--- a/src/libraries/libmetget/src/libmetget/download/adeckdownloader.py
+++ b/src/libraries/libmetget/src/libmetget/download/adeckdownloader.py
@@ -2,6 +2,7 @@ import math
 from datetime import datetime
 from typing import ClassVar, Dict, List
 
+import requests
 from loguru import logger
 
 from libmetget.database.database import Database
@@ -238,6 +239,11 @@ class ADeckDownloader:
                                 track_count += 1
                                 this_storm_track_count += 1
                 except ADeckDownloaderException:
+                    continue
+                except requests.RequestException as e:
+                    logger.warning(
+                        f"Skipping {basin}{storm:02d} due to a connection error: {e}"
+                    )
                     continue
 
                 if this_storm_track_count > 0:


### PR DESCRIPTION
Add a 30s timeout to the adeck HTTP requests and catch requests.RequestException in the per-storm download loop so a flaky upstream server (e.g. hurricanes.ral.ucar.edu) skips the storm with a warning instead of killing the entire run.